### PR TITLE
disable chat on UI unless config `assistant.chat.enabled` is true

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -9,5 +9,8 @@
     "embeddable",
     "opensearchDashboardsReact",
     "opensearchDashboardsUtils"
+  ],
+  "configPath": [
+    "assistant"
   ]
 }

--- a/public/index.ts
+++ b/public/index.ts
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { PluginInitializerContext } from '../../../src/core/public';
 import { AssistantPlugin } from './plugin';
 
 export { AssistantPlugin as Plugin };
 
-export const plugin = () => new AssistantPlugin();
+export function plugin(initializerContext: PluginInitializerContext) {
+  return new AssistantPlugin(initializerContext);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from '../../../src/core/server';
+import { schema, TypeOf } from '@osd/config-schema';
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../src/core/server';
 import { AssistantPlugin } from './plugin';
 
 export function plugin(initializerContext: PluginInitializerContext) {
@@ -11,3 +12,20 @@ export function plugin(initializerContext: PluginInitializerContext) {
 }
 
 export { AssistantPluginSetup, AssistantPluginStart } from './types';
+
+const assistantConfig = {
+  schema: schema.object({
+    chat: schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+    }),
+  }),
+};
+
+export type AssistantConfig = TypeOf<typeof assistantConfig.schema>;
+
+export const config: PluginConfigDescriptor<AssistantConfig> = {
+  schema: assistantConfig.schema,
+  exposeToBrowser: {
+    chat: true,
+  },
+};


### PR DESCRIPTION
### Description
- remove unused configs in opensearch_dashboards.json 
- disable chat on UI unless config `assistant.chat.enabled` is true in opensearch_dashboards.yml

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
