### PR TITLE
remove images in markdown

### DIFF
--- a/server/olly/utils/output_builders/__tests__/build_outputs.test.ts
+++ b/server/olly/utils/output_builders/__tests__/build_outputs.test.ts
@@ -35,14 +35,15 @@ describe('build outputs', () => {
   it('sanitizes markdown outputs', () => {
     const outputs = buildOutputs(
       'test question',
-      'normal text<b onmouseover=alert("XSS testing!")></b>',
+      'normal text<b onmouseover=alert("XSS testing!")></b> <img src="image.jpg" alt="image" width="500" height="600"> !!!!!!![](https://badurl) ![image](https://badurl) [good link](https://link)',
       'test-session',
       {},
       []
     );
     expect(outputs).toEqual([
       {
-        content: 'normal text<b></b>',
+        content:
+          'normal text<b></b>  [](https://badurl) [image](https://badurl) [good link](https://link)',
         contentType: 'markdown',
         traceId: 'test-session',
         suggestedActions: [],

--- a/server/olly/utils/output_builders/build_outputs.ts
+++ b/server/olly/utils/output_builders/build_outputs.ts
@@ -50,6 +50,8 @@ const sanitize = (outputs: IMessage[]) => {
   const DOMPurify = createDOMPurify((window as unknown) as Window);
   return outputs.map((output) => ({
     ...output,
-    ...(output.contentType === 'markdown' && { content: DOMPurify.sanitize(output.content) }),
+    ...(output.contentType === 'markdown' && {
+      content: DOMPurify.sanitize(output.content, { FORBID_TAGS: ['img'] }).replace(/!+\[/g, '['),
+    }),
   }));
 };


### PR DESCRIPTION
### Description
remove images in markdown. olly does not render images using links

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
