### PR TITLE
reduce hallucination in summarization chain

### DIFF
--- a/server/olly/chains/summarization.ts
+++ b/server/olly/chains/summarization.ts
@@ -24,6 +24,8 @@ User's question on index '${context.index}': ${context.question}
 PPL (Piped Processing Language) query used: ${context.query}
 
 Give some documents to support your point.
+Note that the output could be truncated, summarize what you see. Don't mention about total items returned and don't mention about the fact that output is truncated if you see 'Output is too long, truncated' in the response.
+If you only see '{}', then there are no results matching the query.
 
 Skip the introduction; go straight into the summarization.`;
   }

--- a/server/olly/utils/__tests__/utils.test.ts
+++ b/server/olly/utils/__tests__/utils.test.ts
@@ -26,11 +26,10 @@ describe('protect calls', () => {
   });
 
   it('should truncate text if output is too long', async () => {
-    const tool = jest.fn().mockResolvedValue('failed to run in test'.repeat(1000) + 'end message');
+    const tool = jest.fn().mockResolvedValue('failed to run in test'.repeat(1000));
     const truncated = protectCall(tool);
     const res = await truncated('input');
     expect(res).toContain('Output is too long, truncated');
-    expect(res).toContain('end message');
     expect(res.length).toEqual(MAX_OUTPUT_CHAR);
   });
 });

--- a/server/olly/utils/utils.ts
+++ b/server/olly/utils/utils.ts
@@ -27,12 +27,8 @@ export const protectCall = (func: DynamicToolInput['func']): DynamicToolInput['f
 
 export const truncate = (text: string, maxLength: number = MAX_OUTPUT_CHAR) => {
   if (text.length <= maxLength) return text;
-  const tailMessage = '\n\nOutput is too long, truncated... end:\n\n';
-  return (
-    text.slice(0, MAX_OUTPUT_CHAR - tailMessage.length - 300) +
-    tailMessage +
-    text.slice(text.length - 300)
-  );
+  const tailMessage = '\n\nOutput is too long, truncated...';
+  return text.slice(0, MAX_OUTPUT_CHAR - tailMessage.length) + tailMessage;
 };
 
 export const jsonToCsv = (json: object[]) => {


### PR DESCRIPTION
### Description
For better results, we should convert PPL response to CSV in event analytics before sending to summarize API. Currently it is in JDBC format which is difficult to understand.

This PR
- removes the end message when truncating, so LLM is more aware of that the output is truncated
- updates prompt to be aware of output truncation and empty output

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
