### PR TITLE
Fix redirect new session when dock right

### DIFF
--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -11,7 +11,7 @@ import { ApplicationStart } from '../../../src/core/public';
 import { ChatFlyout } from './chat_flyout';
 import { ChatContext, IChatContext } from './contexts/chat_context';
 import { SetContext } from './contexts/set_context';
-import { ChatStateProvider } from './hooks/use_chat_state';
+import { ChatStateProvider } from './hooks';
 import './index.scss';
 import chatIcon from './assets/chat.svg';
 import { ActionExecutor, AssistantActions, ContentRenderer, UserAccount, TabId } from './types';

--- a/public/components/chat_window_header_title.tsx
+++ b/public/components/chat_window_header_title.tsx
@@ -12,13 +12,11 @@ import {
   EuiButtonIcon,
 } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
-import { useChatContext } from '../contexts/chat_context';
-import { useChatActions } from '../hooks/use_chat_actions';
+import { useChatContext } from '../contexts';
+import { useChatActions, useChatState, useSaveChat } from '../hooks';
 import { NotebookNameModal } from './notebook/notebook_name_modal';
 import { ChatExperimentalBadge } from './chat_experimental_badge';
 import { useCore } from '../contexts/core_context';
-import { useChatState } from '../hooks/use_chat_state';
-import { useSaveChat } from '../hooks/use_save_chat';
 import { EditConversationNameModal } from './edit_conversation_name_modal';
 
 export const ChatWindowHeaderTitle = React.memo(() => {

--- a/public/contexts/index.ts
+++ b/public/contexts/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { useChatContext } from './chat_context';
+export { useCore } from './core_context';

--- a/public/contexts/set_context.tsx
+++ b/public/contexts/set_context.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { useChatActions } from '../hooks/use_chat_actions';
+import { useChatActions } from '../hooks';
 import { AssistantActions } from '../types';
 
 interface SetContextProps {

--- a/public/hooks/index.ts
+++ b/public/hooks/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { useSaveChat } from './use_save_chat';

--- a/public/hooks/index.ts
+++ b/public/hooks/index.ts
@@ -4,3 +4,5 @@
  */
 
 export { useSaveChat } from './use_save_chat';
+export { useChatState, ChatStateProvider } from './use_chat_state';
+export { useChatActions } from './use_chat_actions';

--- a/public/tabs/chat/chat_page.tsx
+++ b/public/tabs/chat/chat_page.tsx
@@ -6,12 +6,11 @@
 import { EuiFlyoutBody, EuiFlyoutFooter, EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
 import React, { useCallback, useState } from 'react';
 import cs from 'classnames';
-import { useChatContext } from '../../contexts/chat_context';
-import { useChatState } from '../../hooks/use_chat_state';
+import { useObservable } from 'react-use';
+import { useChatContext, useCore } from '../../contexts';
+import { useChatState } from '../../hooks';
 import { ChatPageContent } from './chat_page_content';
 import { ChatInputControls } from './controls/chat_input_controls';
-import { useObservable } from 'react-use';
-import { useCore } from '../../contexts/core_context';
 
 interface ChatPageProps {
   className?: string;

--- a/public/tabs/chat/chat_page_content.tsx
+++ b/public/tabs/chat/chat_page_content.tsx
@@ -16,13 +16,12 @@ import {
 import React, { useLayoutEffect, useRef } from 'react';
 import { IMessage, ISuggestedAction } from '../../../common/types/chat_saved_object_attributes';
 import { TermsAndConditions } from '../../components/terms_and_conditions';
-import { useChatContext } from '../../contexts/chat_context';
-import { useChatState } from '../../hooks/use_chat_state';
+import { useChatContext } from '../../contexts';
+import { useChatState, useChatActions } from '../../hooks';
 import { ChatPageGreetings } from './chat_page_greetings';
 import { MessageBubble } from './messages/message_bubble';
 import { MessageContent } from './messages/message_content';
 import { SuggestionBubble } from './suggestions/suggestion_bubble';
-import { useChatActions } from '../../hooks/use_chat_actions';
 
 interface ChatPageContentProps {
   showGreetings: boolean;

--- a/public/tabs/chat/controls/chat_input_controls.tsx
+++ b/public/tabs/chat/controls/chat_input_controls.tsx
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiButton, EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiTextArea } from '@elastic/eui';
+import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiTextArea } from '@elastic/eui';
 import autosize from 'autosize';
 import React, { useRef } from 'react';
 import { useEffectOnce } from 'react-use';
 import { IMessage } from '../../../../common/types/chat_saved_object_attributes';
-import { useChatContext } from '../../../contexts/chat_context';
-import { useChatActions } from '../../../hooks/use_chat_actions';
+import { useChatContext } from '../../../contexts';
+import { useChatActions } from '../../../hooks';
 
 interface ChatInputControlsProps {
   disabled: boolean;

--- a/public/tabs/history/__tests__/chat_history_page.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_page.test.tsx
@@ -4,13 +4,12 @@
  */
 
 import React from 'react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { I18nProvider } from '@osd/i18n/react';
 
-import * as useChatStateExports from '../../../hooks/use_chat_state';
-import * as chatContextExports from '../../../contexts/chat_context';
-import * as coreContextExports from '../../../contexts/core_context';
+import * as useChatStateExports from '../../../hooks';
+import * as contextsExports from '../../../contexts';
 
 import { ChatHistoryPage } from '../chat_history_page';
 
@@ -41,9 +40,9 @@ const setup = () => {
     setSessionId: jest.fn(),
     setTitle: jest.fn(),
   };
-  jest.spyOn(coreContextExports, 'useCore').mockReturnValue(useCoreMock);
+  jest.spyOn(contextsExports, 'useCore').mockReturnValue(useCoreMock);
   jest.spyOn(useChatStateExports, 'useChatState').mockReturnValue(useChatStateMock);
-  jest.spyOn(chatContextExports, 'useChatContext').mockReturnValue(useChatContextMock);
+  jest.spyOn(contextsExports, 'useChatContext').mockReturnValue(useChatContextMock);
 
   const renderResult = render(
     <I18nProvider>

--- a/public/tabs/history/__tests__/chat_history_page.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_page.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
+import { I18nProvider } from '@osd/i18n/react';
+
+import * as useChatStateExports from '../../../hooks/use_chat_state';
+import * as chatContextExports from '../../../contexts/chat_context';
+import * as coreContextExports from '../../../contexts/core_context';
+
+import { ChatHistoryPage } from '../chat_history_page';
+
+const setup = () => {
+  const useCoreMock = {
+    services: {
+      sessions: {
+        sessions$: new BehaviorSubject({
+          objects: [
+            {
+              id: '1',
+              title: 'foo',
+            },
+          ],
+          total: 1,
+        }),
+        status$: new BehaviorSubject('idle'),
+        load: jest.fn(),
+      },
+      sessionLoad: {},
+    },
+  };
+  const useChatStateMock = {
+    chatStateDispatch: jest.fn(),
+  };
+  const useChatContextMock = {
+    sessionId: '1',
+    setSessionId: jest.fn(),
+    setTitle: jest.fn(),
+  };
+  jest.spyOn(coreContextExports, 'useCore').mockReturnValue(useCoreMock);
+  jest.spyOn(useChatStateExports, 'useChatState').mockReturnValue(useChatStateMock);
+  jest.spyOn(chatContextExports, 'useChatContext').mockReturnValue(useChatContextMock);
+
+  const renderResult = render(
+    <I18nProvider>
+      <ChatHistoryPage shouldRefresh={false} />
+    </I18nProvider>
+  );
+
+  return {
+    useCoreMock,
+    useChatStateMock,
+    useChatContextMock,
+    renderResult,
+  };
+};
+
+describe('<ChatHistoryPage />', () => {
+  it('should clear old session data after current session deleted', async () => {
+    const { renderResult, useChatStateMock, useChatContextMock } = setup();
+
+    act(() => {
+      fireEvent.click(renderResult.getByLabelText('Delete conversation'));
+    });
+
+    expect(useChatContextMock.setSessionId).not.toHaveBeenCalled();
+    expect(useChatContextMock.setTitle).not.toHaveBeenCalled();
+    expect(useChatStateMock.chatStateDispatch).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(renderResult.getByTestId('confirmModalConfirmButton'));
+    });
+
+    expect(useChatContextMock.setSessionId).toHaveBeenLastCalledWith(undefined);
+    expect(useChatContextMock.setTitle).toHaveBeenLastCalledWith(undefined);
+    expect(useChatStateMock.chatStateDispatch).toHaveBeenLastCalledWith({ type: 'reset' });
+  });
+});

--- a/public/tabs/history/chat_history_page.tsx
+++ b/public/tabs/history/chat_history_page.tsx
@@ -22,8 +22,7 @@ import { useDebounce, useObservable } from 'react-use';
 import cs from 'classnames';
 import { useChatActions } from '../../hooks/use_chat_actions';
 import { useChatState } from '../../hooks/use_chat_state';
-import { useChatContext } from '../../contexts/chat_context';
-import { useCore } from '../../contexts/core_context';
+import { useChatContext, useCore } from '../../contexts';
 import { ChatHistorySearchList } from './chat_history_search_list';
 
 interface ChatHistoryPageProps {

--- a/public/tabs/history/chat_history_page.tsx
+++ b/public/tabs/history/chat_history_page.tsx
@@ -21,6 +21,7 @@ import { FormattedMessage } from '@osd/i18n/react';
 import { useDebounce, useObservable } from 'react-use';
 import cs from 'classnames';
 import { useChatActions } from '../../hooks/use_chat_actions';
+import { useChatState } from '../../hooks/use_chat_state';
 import { useChatContext } from '../../contexts/chat_context';
 import { useCore } from '../../contexts/core_context';
 import { ChatHistorySearchList } from './chat_history_search_list';
@@ -33,7 +34,14 @@ interface ChatHistoryPageProps {
 export const ChatHistoryPage: React.FC<ChatHistoryPageProps> = React.memo((props) => {
   const { services } = useCore();
   const { loadChat } = useChatActions();
-  const { setSelectedTabId, flyoutFullScreen, sessionId } = useChatContext();
+  const { chatStateDispatch } = useChatState();
+  const {
+    setSelectedTabId,
+    flyoutFullScreen,
+    sessionId,
+    setSessionId,
+    setTitle,
+  } = useChatContext();
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [searchName, setSearchName] = useState<string>();
@@ -70,11 +78,13 @@ export const ChatHistoryPage: React.FC<ChatHistoryPageProps> = React.memo((props
   const handleHistoryDeleted = useCallback(
     (id: string) => {
       if (sessionId === id) {
-        // Switch to new conversation when current session be deleted
-        loadChat();
+        // Clear old session chat states
+        setTitle(undefined);
+        setSessionId(undefined);
+        chatStateDispatch({ type: 'reset' });
       }
     },
-    [sessionId, loadChat]
+    [sessionId, setSessionId, setTitle, chatStateDispatch]
   );
 
   useDebounce(

--- a/public/tabs/history/chat_history_page.tsx
+++ b/public/tabs/history/chat_history_page.tsx
@@ -20,8 +20,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 import { useDebounce, useObservable } from 'react-use';
 import cs from 'classnames';
-import { useChatActions } from '../../hooks/use_chat_actions';
-import { useChatState } from '../../hooks/use_chat_state';
+import { useChatActions, useChatState } from '../../hooks';
 import { useChatContext, useCore } from '../../contexts';
 import { ChatHistorySearchList } from './chat_history_search_list';
 

--- a/public/tabs/history/chat_history_search_list.tsx
+++ b/public/tabs/history/chat_history_search_list.tsx
@@ -51,7 +51,7 @@ export const ChatHistorySearchList = ({
   } | null>(null);
   const [deletingConversation, setDeletingConversation] = useState<{ id: string } | null>(null);
 
-  const handleEditConversationCancel = useCallback(
+  const handleEditConversationConfirmModalClose = useCallback(
     (status: 'updated' | string) => {
       if (status === 'updated') {
         onRefresh();
@@ -61,7 +61,7 @@ export const ChatHistorySearchList = ({
     [setEditingConversation, onRefresh]
   );
 
-  const handleDeleteConversationCancel = useCallback(
+  const handleDeleteConversationConfirmModalClose = useCallback(
     (status: 'deleted' | string) => {
       if (status === 'deleted') {
         onRefresh();
@@ -108,7 +108,7 @@ export const ChatHistorySearchList = ({
           />
           {editingConversation && (
             <EditConversationNameModal
-              onClose={handleEditConversationCancel}
+              onClose={handleEditConversationConfirmModalClose}
               sessionId={editingConversation.id}
               defaultTitle={editingConversation.title}
             />
@@ -116,7 +116,7 @@ export const ChatHistorySearchList = ({
           {deletingConversation && (
             <DeleteConversationConfirmModal
               sessionId={deletingConversation.id}
-              onClose={handleDeleteConversationCancel}
+              onClose={handleDeleteConversationConfirmModalClose}
             />
           )}
         </>

--- a/public/tabs/history/chat_history_search_list.tsx
+++ b/public/tabs/history/chat_history_search_list.tsx
@@ -51,7 +51,7 @@ export const ChatHistorySearchList = ({
   } | null>(null);
   const [deletingConversation, setDeletingConversation] = useState<{ id: string } | null>(null);
 
-  const handleEditConversationConfirmModalClose = useCallback(
+  const handleEditConversationModalClose = useCallback(
     (status: 'updated' | string) => {
       if (status === 'updated') {
         onRefresh();
@@ -108,7 +108,7 @@ export const ChatHistorySearchList = ({
           />
           {editingConversation && (
             <EditConversationNameModal
-              onClose={handleEditConversationConfirmModalClose}
+              onClose={handleEditConversationModalClose}
               sessionId={editingConversation.id}
               defaultTitle={editingConversation.title}
             />

--- a/test/__mocks__/fileMock.js
+++ b/test/__mocks__/fileMock.js
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module.exports = 'file-stub';

--- a/test/__mocks__/styleMock.js
+++ b/test/__mocks__/styleMock.js
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module.exports = {};


### PR DESCRIPTION
### Description
Same as #26

Fix jump to new chat page after current session deleted in dock right mode like below video:

https://github.com/opensearch-project/dashboards-assistant/assets/4034161/6f06bf4f-cbbb-4762-bff4-848a19f4f951

It should stay the same page

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
