### PR TITLE
fix: chat history page ut failed by redefine property

### DIFF
--- a/public/tabs/history/__tests__/chat_history_page.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_page.test.tsx
@@ -8,8 +8,9 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { BehaviorSubject } from 'rxjs';
 import { I18nProvider } from '@osd/i18n/react';
 
-import * as useChatStateExports from '../../../hooks';
-import * as contextsExports from '../../../contexts';
+import * as useChatStateExports from '../../../hooks/use_chat_state';
+import * as chatContextExports from '../../../contexts/chat_context';
+import * as coreContextExports from '../../../contexts/core_context';
 
 import { ChatHistoryPage } from '../chat_history_page';
 
@@ -40,9 +41,9 @@ const setup = () => {
     setSessionId: jest.fn(),
     setTitle: jest.fn(),
   };
-  jest.spyOn(contextsExports, 'useCore').mockReturnValue(useCoreMock);
+  jest.spyOn(coreContextExports, 'useCore').mockReturnValue(useCoreMock);
   jest.spyOn(useChatStateExports, 'useChatState').mockReturnValue(useChatStateMock);
-  jest.spyOn(contextsExports, 'useChatContext').mockReturnValue(useChatContextMock);
+  jest.spyOn(chatContextExports, 'useChatContext').mockReturnValue(useChatContextMock);
 
   const renderResult = render(
     <I18nProvider>


### PR DESCRIPTION
### Description

Mock hooks by real file path to avoid redefine property error

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
