### PR TITLE
feat: more robust parser to get suggested actions

### DIFF
--- a/server/parsers/basic_input_output_parser.test.ts
+++ b/server/parsers/basic_input_output_parser.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BasicInputOutputParser } from './basic_input_output_parser';
+import { BasicInputOutputParser, parseSuggestedActions } from './basic_input_output_parser';
 
 describe('BasicInputOutputParser', () => {
   it('return input and output', async () => {
@@ -93,5 +93,39 @@ describe('BasicInputOutputParser', () => {
         suggestedActions: [],
       },
     ]);
+  });
+});
+
+describe('parseSuggestedActions', () => {
+  it('should return parsed array when string matches valid json format', () => {
+    expect(parseSuggestedActions('["1", "2"]')).toEqual(['1', '2']);
+  });
+
+  it('should return parsed array when there is json inside the string', () => {
+    expect(parseSuggestedActions('Here are result { "response": ["1", "2"] }')).toEqual(['1', '2']);
+  });
+
+  it('should return parsed array when there is {} inside the string', () => {
+    expect(parseSuggestedActions('Here are result { "response": ["{1}", "{2}"] }')).toEqual([
+      '{1}',
+      '{2}',
+    ]);
+  });
+
+  it('should return parsed array when there is additional field in response', () => {
+    expect(
+      parseSuggestedActions('Here are result { "response": ["{1}", "{2}"], "foo": "bar" }')
+    ).toEqual(['{1}', '{2}']);
+  });
+
+  it('should return empty array when there the json is invalid', () => {
+    expect(
+      parseSuggestedActions('Here are result { response": ["{1}", "{2}"], "foo": "bar" }')
+    ).toEqual([]);
+  });
+
+  it('should return empty array when input is not valid', () => {
+    expect(parseSuggestedActions('')).toEqual([]);
+    expect(parseSuggestedActions((null as unknown) as string)).toEqual([]);
   });
 });

--- a/server/parsers/basic_input_output_parser.ts
+++ b/server/parsers/basic_input_output_parser.ts
@@ -5,7 +5,8 @@
 
 import createDOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
-import { IInput, IOutput, Interaction } from '../../common/types/chat_saved_object_attributes';
+import { IInput, IOutput } from '../../common/types/chat_saved_object_attributes';
+import { MessageParser } from '../types';
 
 const sanitize = (content: string) => {
   const window = new JSDOM('').window;
@@ -13,47 +14,47 @@ const sanitize = (content: string) => {
   return DOMPurify.sanitize(content, { FORBID_TAGS: ['img'] }).replace(/!+\[/g, '[');
 };
 
-const isEveryItemString = (array?: unknown) =>
-  !!(Array.isArray(array) && array.every((item) => typeof item === 'string'));
+const isStringArray = (array?: unknown): array is string[] =>
+  Array.isArray(array) && array.every((item) => typeof item === 'string');
 
-export const parseSuggestedActions = (string: string): string[] => {
-  if (!string) {
+export const parseSuggestedActions = (value: string): string[] => {
+  if (!value) {
     return [];
   }
-  const suggestedOutputString = string;
+  const suggestedOutputString = value;
   let suggestedActions: string[] = [];
   try {
-    suggestedActions = JSON.parse(suggestedOutputString || '[]');
+    suggestedActions = JSON.parse(suggestedOutputString);
   } catch (e) {
     suggestedActions = [];
   }
 
   if (suggestedActions.length) {
-    return suggestedActions;
+    if (isStringArray(suggestedActions)) {
+      return suggestedActions;
+    }
+
+    return [];
   }
 
   /**
    * Get json-like substring from a string
    *
-   *  /\{               // Match an opening curly brace
-   *    (?:            // Start a non-capturing group
-   *      [^{}]        // Match any character that is not a curly brace
-   *      |            // OR
-   *      (?:          // Start a non-capturing group
-   *        \{         // Match an opening curly brace
-   *        [^{}]*     // Match any characters that are not curly braces (allowing nested structures)
-   *        \}         // Match a closing curly brace
-   *      )
-   *    )*             // Repeat the non-capturing group zero or more times (allowing nested structures)
+   *  /\{                  // Match an opening curly brace
+   *    .*                 // Match any preleading spaces and letters
+   *    response[^\n]*\:   // Match "response" key because suggestion tool uses { response: [action1, action2] }
+   *                       // in its prompt so that the parsedResult may contain a "response" field.
+   *                       // If prompt changed, the logic here need to change accordingly.
+   *    .*                 // Match any any string behind the "response:"
    *  \}/g             // Match a closing curly brace, and 'g' flag for global search
    *
    */
-  const jsonPattern = /\{(?:[^{}]|(?:\{[^{}]*\}))*\}/g;
+  const jsonPattern = /\{.*response[^\n]*\:.*\}/g;
 
   /**
    * Use the regular expression to find the JSON substring
    */
-  const match = string.match(jsonPattern);
+  const match = value.match(jsonPattern);
 
   const matchedResult = match && match[0];
 
@@ -64,12 +65,7 @@ export const parseSuggestedActions = (string: string): string[] => {
   try {
     const parsedResult = JSON.parse(matchedResult);
 
-    /**
-     * Suggestion tool uses { response: [action1, action2] } in its prompt
-     * so that the parsedResult may contains a response field.
-     * If prompt changed, the logic here need to change accordingly.
-     */
-    if (parsedResult?.response && isEveryItemString(parsedResult.response)) {
+    if (parsedResult?.response && isStringArray(parsedResult.response)) {
       return parsedResult.response;
     }
   } catch (e) {
@@ -79,13 +75,20 @@ export const parseSuggestedActions = (string: string): string[] => {
   return [];
 };
 
-export const BasicInputOutputParser = {
+export const BasicInputOutputParser: MessageParser = {
   order: 0,
   id: 'output_message',
-  async parserProvider(interaction: Interaction) {
-    const suggestedActions = parseSuggestedActions(
-      (interaction.additional_info?.['QuestionSuggestor.output'] as string | null) || ''
-    );
+  async parserProvider(interaction, options) {
+    /**
+     * From UX, only the last interaction need to parse suggestedActions.
+     */
+    const isLatestInteraction =
+      options.interactions.reverse()[0]?.interaction_id === interaction.interaction_id;
+    const suggestedActions = isLatestInteraction
+      ? parseSuggestedActions(
+          (interaction.additional_info?.['QuestionSuggestor.output'] as string | null) || ''
+        )
+      : [];
     const inputItem: IInput = {
       type: 'input',
       contentType: 'text',

--- a/server/parsers/basic_input_output_parser.ts
+++ b/server/parsers/basic_input_output_parser.ts
@@ -13,19 +13,79 @@ const sanitize = (content: string) => {
   return DOMPurify.sanitize(content, { FORBID_TAGS: ['img'] }).replace(/!+\[/g, '[');
 };
 
+const isEveryItemString = (array?: unknown) =>
+  !!(Array.isArray(array) && array.every((item) => typeof item === 'string'));
+
+export const parseSuggestedActions = (string: string): string[] => {
+  if (!string) {
+    return [];
+  }
+  const suggestedOutputString = string;
+  let suggestedActions: string[] = [];
+  try {
+    suggestedActions = JSON.parse(suggestedOutputString || '[]');
+  } catch (e) {
+    suggestedActions = [];
+  }
+
+  if (suggestedActions.length) {
+    return suggestedActions;
+  }
+
+  /**
+   * Get json-like substring from a string
+   *
+   *  /\{               // Match an opening curly brace
+   *    (?:            // Start a non-capturing group
+   *      [^{}]        // Match any character that is not a curly brace
+   *      |            // OR
+   *      (?:          // Start a non-capturing group
+   *        \{         // Match an opening curly brace
+   *        [^{}]*     // Match any characters that are not curly braces (allowing nested structures)
+   *        \}         // Match a closing curly brace
+   *      )
+   *    )*             // Repeat the non-capturing group zero or more times (allowing nested structures)
+   *  \}/g             // Match a closing curly brace, and 'g' flag for global search
+   *
+   */
+  const jsonPattern = /\{(?:[^{}]|(?:\{[^{}]*\}))*\}/g;
+
+  /**
+   * Use the regular expression to find the JSON substring
+   */
+  const match = string.match(jsonPattern);
+
+  const matchedResult = match && match[0];
+
+  if (!matchedResult) {
+    return [];
+  }
+
+  try {
+    const parsedResult = JSON.parse(matchedResult);
+
+    /**
+     * Suggestion tool uses { response: [action1, action2] } in its prompt
+     * so that the parsedResult may contains a response field.
+     * If prompt changed, the logic here need to change accordingly.
+     */
+    if (parsedResult?.response && isEveryItemString(parsedResult.response)) {
+      return parsedResult.response;
+    }
+  } catch (e) {
+    return [];
+  }
+
+  return [];
+};
+
 export const BasicInputOutputParser = {
   order: 0,
   id: 'output_message',
   async parserProvider(interaction: Interaction) {
-    const suggestedOutputString = interaction.additional_info?.['QuestionSuggestor.output'] as
-      | string
-      | null;
-    let suggestedActions: string[] = [];
-    try {
-      suggestedActions = JSON.parse(suggestedOutputString || '[]');
-    } catch (e) {
-      suggestedActions = [];
-    }
+    const suggestedActions = parseSuggestedActions(
+      (interaction.additional_info?.['QuestionSuggestor.output'] as string | null) || ''
+    );
     const inputItem: IInput = {
       type: 'input',
       contentType: 'text',

--- a/server/services/storage/agent_framework_storage_service.ts
+++ b/server/services/storage/agent_framework_storage_service.ts
@@ -56,7 +56,10 @@ export class AgentFrameworkStorageService implements StorageService {
 
     let finalMessages: IMessage[] = [];
     for (const interaction of finalInteractions) {
-      finalMessages = [...finalMessages, ...(await messageParserRunner.run(interaction))];
+      finalMessages = [
+        ...finalMessages,
+        ...(await messageParserRunner.run(interaction, { interactions: finalInteractions })),
+      ];
     }
     return {
       title: conversation.body.name,

--- a/server/types.ts
+++ b/server/types.ts
@@ -11,6 +11,10 @@ export interface AssistantPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AssistantPluginStart {}
 
+export interface ProviderOptions {
+  interactions: Interaction[];
+}
+
 export interface MessageParser {
   /**
    * The id of the parser, should be unique among the parsers.
@@ -26,7 +30,7 @@ export interface MessageParser {
   /**
    * parserProvider is the callback that will be triggered in each message
    */
-  parserProvider: (interaction: Interaction) => Promise<IMessage[]>;
+  parserProvider: (interaction: Interaction, options: ProviderOptions) => Promise<IMessage[]>;
 }
 
 export interface RoutesOptions {

--- a/server/utils/message_parser_runner.ts
+++ b/server/utils/message_parser_runner.ts
@@ -4,11 +4,11 @@
  */
 
 import { IMessage, Interaction } from '../../common/types/chat_saved_object_attributes';
-import { MessageParser } from '../types';
+import { MessageParser, ProviderOptions } from '../types';
 
 export class MessageParserRunner {
   constructor(private readonly messageParsers: MessageParser[]) {}
-  async run(interaction: Interaction): Promise<IMessage[]> {
+  async run(interaction: Interaction, options: ProviderOptions): Promise<IMessage[]> {
     const sortedParsers = [...this.messageParsers];
     sortedParsers.sort((parserA, parserB) => {
       const { order: orderA = 999 } = parserA;
@@ -19,7 +19,7 @@ export class MessageParserRunner {
     for (const messageParser of sortedParsers) {
       let tempResult: IMessage[] = [];
       try {
-        tempResult = await messageParser.parserProvider(interaction);
+        tempResult = await messageParser.parserProvider(interaction, options);
         /**
          * Make sure the tempResult is an array.
          */


### PR DESCRIPTION
### Description
The suggested actions tool may output a response like
```
Here are result { "response": ["{1}", "{2}"], "foo": "bar" }
```
We need a more robust parser to get the json inside the response and make it as our suggestions.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
