### PR TITLE
test: add unit tests for session load and sessions service

### DIFF
--- a/public/services/__tests__/session_load_service.test.ts
+++ b/public/services/__tests__/session_load_service.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpHandler } from '../../../../../src/core/public';
+import { httpServiceMock } from '../../../../../src/core/public/mocks';
+import { SessionLoadService } from '../session_load_service';
+
+const setup = () => {
+  const http = httpServiceMock.createSetupContract();
+  const sessionLoad = new SessionLoadService(http);
+
+  return {
+    sessionLoad,
+    http,
+  };
+};
+
+describe('SessionLoadService', () => {
+  it('should emit loading status and call get with specific session id', () => {
+    const { sessionLoad, http } = setup();
+
+    sessionLoad.load('foo');
+    expect(http.get).toHaveBeenCalledWith(
+      '/api/assistant/session/foo',
+      expect.objectContaining({
+        signal: expect.anything(),
+      })
+    );
+    expect(sessionLoad.status$.getValue()).toBe('loading');
+  });
+
+  it('should resolved with response data and "idle" status', async () => {
+    const { sessionLoad, http } = setup();
+    http.get.mockReturnValue(Promise.resolve({ id: '1', title: 'foo' }));
+
+    const result = await sessionLoad.load('foo');
+    expect(result).toEqual({ id: '1', title: 'foo' });
+    expect(sessionLoad.status$.getValue()).toBe('idle');
+  });
+
+  it('should emit error after loading aborted', async () => {
+    const { sessionLoad, http } = setup();
+    const abortError = new Error('Aborted');
+    http.get.mockImplementation(((_path, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.onabort = () => {
+            reject(abortError);
+          };
+        }
+      });
+    }) as HttpHandler);
+    const loadResult = sessionLoad.load('foo');
+    sessionLoad.abortController?.abort();
+
+    await loadResult;
+
+    expect(sessionLoad.status$.getValue()).toEqual({ status: 'error', error: abortError });
+  });
+});

--- a/public/services/__tests__/sessions_service.test.ts
+++ b/public/services/__tests__/sessions_service.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpHandler } from '../../../../../src/core/public';
+import { httpServiceMock } from '../../../../../src/core/public/mocks';
+import { SessionsService } from '../sessions_service';
+
+const setup = () => {
+  const http = httpServiceMock.createSetupContract();
+  const sessions = new SessionsService(http);
+
+  return {
+    sessions,
+    http,
+  };
+};
+
+describe('SessionsService', () => {
+  it('should emit loading status and call get with sessions API path', () => {
+    const { sessions, http } = setup();
+
+    sessions.load();
+    expect(http.get).toHaveBeenCalledWith(
+      '/api/assistant/sessions',
+      expect.objectContaining({
+        signal: expect.anything(),
+      })
+    );
+    expect(sessions.status$.getValue()).toBe('loading');
+  });
+
+  it('should update options property and call get with passed query', () => {
+    const { sessions, http } = setup();
+
+    expect(sessions.options).toBeFalsy();
+    sessions.load({
+      page: 1,
+      perPage: 10,
+    });
+    expect(sessions.options).toEqual({
+      page: 1,
+      perPage: 10,
+    });
+    expect(http.get).toHaveBeenCalledWith(
+      '/api/assistant/sessions',
+      expect.objectContaining({
+        query: {
+          page: 1,
+          perPage: 10,
+        },
+        signal: expect.anything(),
+      })
+    );
+  });
+
+  it('should emit latest sessions and "idle" status', async () => {
+    const { sessions, http } = setup();
+    http.get.mockReturnValue(Promise.resolve({ objects: [{ id: '1', title: 'foo' }], total: 1 }));
+
+    await sessions.load();
+
+    expect(sessions.status$.getValue()).toBe('idle');
+    expect(sessions.sessions$.getValue()).toEqual({
+      objects: [{ id: '1', title: 'foo' }],
+      total: 1,
+    });
+  });
+
+  it('should call get with same query again after reload called', async () => {
+    const { sessions, http } = setup();
+
+    await sessions.load({
+      page: 1,
+      perPage: 10,
+    });
+    http.get.mockClear();
+
+    sessions.reload();
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(http.get).toHaveBeenCalledWith(
+      '/api/assistant/sessions',
+      expect.objectContaining({
+        query: {
+          page: 1,
+          perPage: 10,
+        },
+        signal: expect.anything(),
+      })
+    );
+  });
+
+  it('should emit error after loading aborted', async () => {
+    const { sessions, http } = setup();
+    const abortError = new Error('Aborted');
+    http.get.mockImplementation(((_path, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.onabort = () => {
+            reject(abortError);
+          };
+        }
+      });
+    }) as HttpHandler);
+    const loadResult = sessions.load();
+    sessions.abortController?.abort();
+
+    await loadResult;
+
+    expect(sessions.status$.getValue()).toEqual({ error: abortError });
+    expect(sessions.sessions$.getValue()).toEqual(null);
+  });
+});

--- a/public/services/session_load_service.ts
+++ b/public/services/session_load_service.ts
@@ -21,13 +21,13 @@ export class SessionLoadService {
     this.status$.next('loading');
     this.abortController = new AbortController();
     try {
-      return await this._http.get<ISession>(`${ASSISTANT_API.SESSION}/${sessionId}`, {
+      const payload = await this._http.get<ISession>(`${ASSISTANT_API.SESSION}/${sessionId}`, {
         signal: this.abortController.signal,
       });
+      this.status$.next('idle');
+      return payload;
     } catch (error) {
       this.status$.next({ status: 'error', error });
-    } finally {
-      this.status$.next('idle');
     }
   };
 }

--- a/public/services/sessions_service.ts
+++ b/public/services/sessions_service.ts
@@ -41,11 +41,10 @@ export class SessionsService {
           signal: this.abortController.signal,
         })
       );
+      this.status$.next('idle');
     } catch (error) {
       this.sessions$.next(null);
       this.status$.next({ error });
-    } finally {
-      this.status$.next('idle');
     }
   };
 


### PR DESCRIPTION
### Description
1. Fix status turn to idle after load failed
2. Add unit tests for session load and sessions service

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
