### PR TITLE
Add unit test for useFetchAgentFrameworkTraces Hook

### DIFF
--- a/public/hooks/use_fetch_agentframework_traces.test.ts
+++ b/public/hooks/use_fetch_agentframework_traces.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useFetchAgentFrameworkTraces } from './use_fetch_agentframework_traces';
+import { createOpenSearchDashboardsReactContext } from '../../../../src/plugins/opensearch_dashboards_react/public';
+import { coreMock } from '../../../../src/core/public/mocks';
+
+describe('useFetchAgentFrameworkTraces hook', () => {
+  it('return undefined when trace id is not specfied', () => {
+    const { result } = renderHook(() => useFetchAgentFrameworkTraces(''));
+    expect(result.current).toEqual({
+      data: undefined,
+      loading: false,
+    });
+  });
+
+  it('return trace data successfully', async () => {
+    const services = coreMock.createStart();
+    const { Provider: wrapper } = createOpenSearchDashboardsReactContext(services);
+    const traces = [
+      {
+        interactionId: 'test_interactionId',
+        parentInteractionId: 'test_parent_interactionId',
+        input: 'input',
+        output: 'output',
+        createTime: '',
+        origin: '',
+        traceNumber: 1,
+      },
+    ];
+
+    services.http.get.mockResolvedValueOnce(traces);
+    const { result, waitForNextUpdate } = renderHook(
+      () => useFetchAgentFrameworkTraces('traceId'),
+      {
+        wrapper,
+      }
+    );
+
+    await waitForNextUpdate();
+    expect(services.http.get).toHaveBeenCalledWith('/api/assistant/trace/traceId');
+
+    expect(result.current).toEqual({
+      data: traces,
+      loading: false,
+    });
+  });
+
+  it('return error when fetch trace error happend', async () => {
+    const traceId = 'foo';
+    const services = coreMock.createStart();
+    const { Provider: wrapper } = createOpenSearchDashboardsReactContext(services);
+
+    services.http.get.mockRejectedValue(new Error('trace not found'));
+    const { result, waitForNextUpdate } = renderHook(() => useFetchAgentFrameworkTraces(traceId), {
+      wrapper,
+    });
+
+    await waitForNextUpdate();
+
+    expect(services.http.get).toHaveBeenCalledWith('/api/assistant/trace/foo');
+
+    expect(result.current).toEqual({
+      data: undefined,
+      loading: false,
+      error: new Error('trace not found'),
+    });
+  });
+});

--- a/public/hooks/use_fetch_agentframework_traces.ts
+++ b/public/hooks/use_fetch_agentframework_traces.ts
@@ -33,7 +33,7 @@ export const useFetchAgentFrameworkTraces = (traceId: string) => {
       .catch((error) => dispatch({ type: 'failure', error }));
 
     return () => abortController.abort();
-  }, [traceId]);
+  }, [core.services.http, traceId]);
 
   return { ...state };
 };

--- a/public/hooks/use_fetch_agentframework_traces.ts
+++ b/public/hooks/use_fetch_agentframework_traces.ts
@@ -23,7 +23,9 @@ export const useFetchAgentFrameworkTraces = (traceId: string) => {
     }
 
     core.services.http
-      .get<AgentFrameworkTrace[]>(`${ASSISTANT_API.TRACE}/${traceId}`)
+      .get<AgentFrameworkTrace[]>(`${ASSISTANT_API.TRACE}/${traceId}`, {
+        signal: abortController.signal,
+      })
       .then((payload) =>
         dispatch({
           type: 'success',

--- a/public/hooks/use_fetch_agentframework_traces.ts
+++ b/public/hooks/use_fetch_agentframework_traces.ts
@@ -32,7 +32,10 @@ export const useFetchAgentFrameworkTraces = (traceId: string) => {
           payload,
         })
       )
-      .catch((error) => dispatch({ type: 'failure', error }));
+      .catch((error) => {
+        if (error.name === 'AbortError') return;
+        dispatch({ type: 'failure', error });
+      });
 
     return () => abortController.abort();
   }, [core.services.http, traceId]);


### PR DESCRIPTION
### Description
Add unit test for useFetchAgentFrameworkTraces

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
