### PR TITLE
[Feature] Add rootAgentId config in dashboard yml file

### DIFF
--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -42,9 +42,6 @@ export const HeaderChatButton: React.FC<HeaderChatButtonProps> = (props) => {
   const [inputFocus, setInputFocus] = useState(false);
   const flyoutFullScreen = chatSize === 'fullscreen';
   const inputRef = useRef<HTMLInputElement>(null);
-  const [rootAgentId, setRootAgentId] = useState<string>(
-    new URL(window.location.href).searchParams.get('agent_id') || ''
-  );
 
   if (!flyoutLoaded && flyoutVisible) flyoutLoaded = true;
 
@@ -80,7 +77,6 @@ export const HeaderChatButton: React.FC<HeaderChatButtonProps> = (props) => {
       setTitle,
       traceId,
       setTraceId,
-      rootAgentId,
     }),
     [
       appId,

--- a/public/contexts/chat_context.tsx
+++ b/public/contexts/chat_context.tsx
@@ -25,7 +25,6 @@ export interface IChatContext {
   setTitle: React.Dispatch<React.SetStateAction<string | undefined>>;
   traceId?: string;
   setTraceId: React.Dispatch<React.SetStateAction<string | undefined>>;
-  rootAgentId?: string;
 }
 export const ChatContext = React.createContext<IChatContext | null>(null);
 

--- a/public/hooks/use_chat_actions.test.tsx
+++ b/public/hooks/use_chat_actions.test.tsx
@@ -64,7 +64,6 @@ describe('useChatActions hook', () => {
   const setTraceIdMock = jest.fn();
 
   const chatContextMock = {
-    rootAgentId: 'root_agent_id_mock',
     selectedTabId: 'chat',
     setSessionId: jest.fn(),
     setTitle: jest.fn(),
@@ -109,7 +108,6 @@ describe('useChatActions hook', () => {
     // it should call send message api
     expect(httpMock.post).toHaveBeenCalledWith(ASSISTANT_API.SEND_MESSAGE, {
       body: JSON.stringify({
-        rootAgentId: 'root_agent_id_mock',
         messages: [],
         input: INPUT_MESSAGE,
       }),
@@ -173,7 +171,6 @@ describe('useChatActions hook', () => {
     // sending message with the suggestion
     expect(httpMock.post).toHaveBeenCalledWith(ASSISTANT_API.SEND_MESSAGE, {
       body: JSON.stringify({
-        rootAgentId: 'root_agent_id_mock',
         messages: [],
         input: { type: 'input', content: 'message that send as input', contentType: 'text' },
       }),
@@ -255,7 +252,6 @@ describe('useChatActions hook', () => {
     expect(httpMock.put).toHaveBeenCalledWith(ASSISTANT_API.REGENERATE, {
       body: JSON.stringify({
         sessionId: 'session_id_mock',
-        rootAgentId: 'root_agent_id_mock',
         interactionId: 'interaction_id_mock',
       }),
     });
@@ -281,7 +277,6 @@ describe('useChatActions hook', () => {
     expect(httpMock.put).toHaveBeenCalledWith(ASSISTANT_API.REGENERATE, {
       body: JSON.stringify({
         sessionId: 'session_id_mock',
-        rootAgentId: 'root_agent_id_mock',
         interactionId: 'interaction_id_mock',
       }),
     });

--- a/public/hooks/use_chat_actions.tsx
+++ b/public/hooks/use_chat_actions.tsx
@@ -38,7 +38,6 @@ export const useChatActions = (): AssistantActions => {
         // do not send abort signal to http client to allow LLM call run in background
         body: JSON.stringify({
           sessionId: chatContext.sessionId,
-          rootAgentId: chatContext.rootAgentId,
           ...(!chatContext.sessionId && { messages: chatState.messages }), // include all previous messages for new chats
           input,
         }),
@@ -168,7 +167,6 @@ export const useChatActions = (): AssistantActions => {
         const response = await core.services.http.put(`${ASSISTANT_API.REGENERATE}`, {
           body: JSON.stringify({
             sessionId: chatContext.sessionId,
-            rootAgentId: chatContext.rootAgentId,
             interactionId,
           }),
         });

--- a/public/index.ts
+++ b/public/index.ts
@@ -11,3 +11,5 @@ export { AssistantPlugin as Plugin };
 export function plugin(initializerContext: PluginInitializerContext) {
   return new AssistantPlugin(initializerContext);
 }
+
+export { AssistantSetup } from './types';

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -30,6 +30,7 @@ interface PublicConfig {
   chat: {
     // whether chat feature is enabled, UI should hide if false
     enabled: boolean;
+    rootAgentId?: string;
   };
 }
 
@@ -74,7 +75,7 @@ export class AssistantPlugin
     const checkAccess = (account: Awaited<ReturnType<typeof getAccount>>) =>
       account.data.roles.some((role) => ['all_access', 'assistant_user'].includes(role));
 
-    if (this.config.chat.enabled) {
+    if (this.config.chat.enabled && this.config.chat.rootAgentId) {
       core.getStartServices().then(async ([coreStart, startDeps]) => {
         const CoreContext = createOpenSearchDashboardsReactContext<AssistantServices>({
           ...coreStart,

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ const assistantConfig = {
   schema: schema.object({
     chat: schema.object({
       enabled: schema.boolean({ defaultValue: false }),
+      rootAgentId: schema.maybe(schema.string()),
     }),
   }),
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,7 +11,7 @@ export function plugin(initializerContext: PluginInitializerContext) {
   return new AssistantPlugin(initializerContext);
 }
 
-export { AssistantPluginSetup, AssistantPluginStart } from './types';
+export { AssistantPluginSetup, AssistantPluginStart, MessageParser } from './types';
 
 const assistantConfig = {
   schema: schema.object({

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -16,6 +16,7 @@ import { setupRoutes } from './routes/index';
 import { AssistantPluginSetup, AssistantPluginStart, MessageParser } from './types';
 import { BasicInputOutputParser } from './parsers/basic_input_output_parser';
 import { VisualizationCardParser } from './parsers/visualization_card_parser';
+import { AgentIdNotFoundError } from './routes/chat_routes';
 
 export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPluginStart> {
   private readonly logger: Logger;
@@ -31,6 +32,15 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
       .create<AssistantConfig>()
       .pipe(first())
       .toPromise();
+
+    /**
+     * Check if user enable the chat without specifying a root agent id.
+     * If so, gives a warning for guidance.
+     */
+    if (config.chat.enabled && !config.chat.rootAgentId) {
+      this.logger.warn(AgentIdNotFoundError);
+    }
+
     const router = core.http.createRouter();
 
     core.http.registerRouteHandlerContext('assistant_plugin', () => {

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -43,6 +43,7 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
     // Register server side APIs
     setupRoutes(router, {
       messageParsers: this.messageParsers,
+      rootAgentId: config.chat.rootAgentId,
     });
 
     core.capabilities.registerProvider(() => ({

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -25,7 +25,7 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
     this.logger = initializerContext.logger.get();
   }
 
-  public async setup(core: CoreSetup) {
+  public async setup(core: CoreSetup): Promise<AssistantPluginSetup> {
     this.logger.debug('Assistant: Setup');
     const config = await this.initializerContext.config
       .create<AssistantConfig>()

--- a/server/routes/chat_routes.ts
+++ b/server/routes/chat_routes.ts
@@ -36,6 +36,9 @@ const llmRequestRoute = {
 };
 export type LLMRequestSchema = TypeOf<typeof llmRequestRoute.validate.body>;
 
+export const AgentIdNotFoundError =
+  'rootAgentId is required, please specify one in opensearch_dashboards.yml';
+
 const getSessionRoute = {
   path: `${ASSISTANT_API.SESSION}/{sessionId}`,
   validate: {
@@ -141,7 +144,8 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       response
     ): Promise<IOpenSearchDashboardsResponse<HttpResponsePayload | ResponseError>> => {
       if (!routeOptions.rootAgentId) {
-        return response.custom({ statusCode: 400, body: 'rootAgentId is required' });
+        context.assistant_plugin.logger.error(AgentIdNotFoundError);
+        return response.custom({ statusCode: 400, body: AgentIdNotFoundError });
       }
       const { messages = [], input, sessionId: sessionIdInRequestBody } = request.body;
       const storageService = createStorageService(context);
@@ -321,7 +325,8 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       response
     ): Promise<IOpenSearchDashboardsResponse<HttpResponsePayload | ResponseError>> => {
       if (!routeOptions.rootAgentId) {
-        return response.custom({ statusCode: 400, body: 'rootAgentId is required' });
+        context.assistant_plugin.logger.error(AgentIdNotFoundError);
+        return response.custom({ statusCode: 400, body: AgentIdNotFoundError });
       }
       const { sessionId, interactionId } = request.body;
       const storageService = createStorageService(context);

--- a/server/routes/regenerate.test.ts
+++ b/server/routes/regenerate.test.ts
@@ -41,7 +41,7 @@ describe('regenerate route when rootAgentId is provided', () => {
   beforeEach(() => {
     loggerMock.clear(mockedLogger);
   });
-  it('return back successfully when requestLLM returns momery back', async () => {
+  it('return back successfully when regenerate returns momery back', async () => {
     mockOllyChatService.regenerate.mockImplementationOnce(async () => {
       return {
         messages: [],
@@ -73,7 +73,7 @@ describe('regenerate route when rootAgentId is provided', () => {
     `);
   });
 
-  it('log error when requestLLM throws an error', async () => {
+  it('log error when regenerate throws an error', async () => {
     mockOllyChatService.regenerate.mockImplementationOnce(() => {
       throw new Error('something went wrong');
     });

--- a/server/routes/regenerate.test.ts
+++ b/server/routes/regenerate.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ResponseObject } from '@hapi/hapi';
+import { Boom } from '@hapi/boom';
+import { Router } from '../../../../src/core/server/http/router';
+import { enhanceWithContext, triggerHandler } from './router.mock';
+import { mockOllyChatService } from '../services/chat/olly_chat_service.mock';
+import { mockAgentFrameworkStorageService } from '../services/storage/agent_framework_storage_service.mock';
+import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';
+import { loggerMock } from '../../../../src/core/server/logging/logger.mock';
+import { registerChatRoutes, RegenerateSchema, AgentIdNotFoundError } from './chat_routes';
+import { ASSISTANT_API } from '../../common/constants/llm';
+
+const mockedLogger = loggerMock.create();
+
+describe('regenerate route when rootAgentId is provided', () => {
+  const router = new Router(
+    '',
+    mockedLogger,
+    enhanceWithContext({
+      assistant_plugin: {
+        logger: mockedLogger,
+      },
+    })
+  );
+  registerChatRoutes(router, {
+    messageParsers: [],
+    rootAgentId: 'foo',
+  });
+  const regenerateRequest = (payload: RegenerateSchema) =>
+    triggerHandler(router, {
+      method: 'put',
+      path: ASSISTANT_API.REGENERATE,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+      }),
+    });
+  beforeEach(() => {
+    loggerMock.clear(mockedLogger);
+  });
+  it('return back successfully when requestLLM returns momery back', async () => {
+    mockOllyChatService.regenerate.mockImplementationOnce(async () => {
+      return {
+        messages: [],
+        memoryId: 'foo',
+      };
+    });
+    mockAgentFrameworkStorageService.getSession.mockImplementationOnce(async () => {
+      return {
+        messages: [],
+        title: 'foo',
+        interactions: [],
+        createdTimeMs: 0,
+        updatedTimeMs: 0,
+      };
+    });
+    const result = (await regenerateRequest({
+      sessionId: 'foo',
+      interactionId: 'bar',
+    })) as ResponseObject;
+    expect(result.source).toMatchInlineSnapshot(`
+      Object {
+        "createdTimeMs": 0,
+        "interactions": Array [],
+        "messages": Array [],
+        "sessionId": "foo",
+        "title": "foo",
+        "updatedTimeMs": 0,
+      }
+    `);
+  });
+
+  it('log error when requestLLM throws an error', async () => {
+    mockOllyChatService.regenerate.mockImplementationOnce(() => {
+      throw new Error('something went wrong');
+    });
+    mockAgentFrameworkStorageService.getSession.mockImplementationOnce(async () => {
+      return {
+        messages: [],
+        title: 'foo',
+        interactions: [],
+        createdTimeMs: 0,
+        updatedTimeMs: 0,
+      };
+    });
+    const result = (await regenerateRequest({
+      sessionId: 'foo',
+      interactionId: 'bar',
+    })) as ResponseObject;
+    expect(mockedLogger.error).toBeCalledTimes(1);
+    expect(result.source).toMatchInlineSnapshot(`
+      Object {
+        "createdTimeMs": 0,
+        "interactions": Array [],
+        "messages": Array [],
+        "sessionId": "foo",
+        "title": "foo",
+        "updatedTimeMs": 0,
+      }
+    `);
+  });
+
+  it('return 500 when get session throws an error', async () => {
+    mockOllyChatService.regenerate.mockImplementationOnce(async () => {
+      return {
+        messages: [],
+        memoryId: 'foo',
+      };
+    });
+    mockAgentFrameworkStorageService.getSession.mockImplementationOnce(() => {
+      throw new Error('foo');
+    });
+    const result = (await regenerateRequest({
+      sessionId: 'foo',
+      interactionId: 'bar',
+    })) as Boom;
+    expect(mockedLogger.error).toBeCalledTimes(1);
+    expect(mockedLogger.error).toBeCalledWith(new Error('foo'));
+    expect(result.output).toMatchInlineSnapshot(`
+        Object {
+          "headers": Object {},
+          "payload": Object {
+            "error": "Internal Server Error",
+            "message": "foo",
+            "statusCode": 500,
+          },
+          "statusCode": 500,
+        }
+      `);
+  });
+});
+
+describe('regenerate route when rootAgentId is not provided', () => {
+  const router = new Router(
+    '',
+    mockedLogger,
+    enhanceWithContext({
+      assistant_plugin: {
+        logger: mockedLogger,
+      },
+    })
+  );
+  registerChatRoutes(router, {
+    messageParsers: [],
+  });
+  const regenerateRequest = (payload: RegenerateSchema) =>
+    triggerHandler(router, {
+      method: 'put',
+      path: ASSISTANT_API.REGENERATE,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+      }),
+    });
+  beforeEach(() => {
+    loggerMock.clear(mockedLogger);
+  });
+
+  it('return 400', async () => {
+    const result = (await regenerateRequest({
+      interactionId: 'bar',
+      sessionId: 'foo',
+    })) as Boom;
+    expect(mockedLogger.error).toBeCalledTimes(1);
+    expect(mockedLogger.error).toBeCalledWith(AgentIdNotFoundError);
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Bad Request",
+          "message": "rootAgentId is required, please specify one in opensearch_dashboards.yml",
+          "statusCode": 400,
+        },
+        "statusCode": 400,
+      }
+    `);
+  });
+});

--- a/server/routes/router.mock.ts
+++ b/server/routes/router.mock.ts
@@ -20,10 +20,12 @@ import { httpServerMock } from '../../../../src/core/server/http/http_server.moc
 import {
   OpenSearchDashboardsRequest,
   OpenSearchDashboardsResponseFactory,
+  RouteMethod,
   Router,
 } from '../../../../src/core/server/http/router';
 import { CoreRouteHandlerContext } from '../../../../src/core/server/core_route_handler_context';
 import { coreMock } from '../../../../src/core/server/mocks';
+import { ContextEnhancer } from '../../../../src/core/server/http/router/router';
 
 /**
  * For hapi, ResponseToolkit is an internal implementation
@@ -91,7 +93,7 @@ export class MockResponseToolkit implements ResponseToolkit {
   }
 }
 
-const enhanceWithContext = (otherContext?: object) => (fn: (...args: unknown[]) => unknown) => (
+const enhanceWithContext = (((otherContext?: object) => (fn: (...args: unknown[]) => unknown) => (
   req: OpenSearchDashboardsRequest,
   res: OpenSearchDashboardsResponseFactory
 ) => {
@@ -105,7 +107,9 @@ const enhanceWithContext = (otherContext?: object) => (fn: (...args: unknown[]) 
     req,
     res
   );
-};
+}) as unknown) as (
+  otherContext?: object
+) => ContextEnhancer<unknown, unknown, unknown, RouteMethod>;
 
 const triggerHandler = async (
   router: Router,

--- a/server/routes/send_message.test.ts
+++ b/server/routes/send_message.test.ts
@@ -58,7 +58,6 @@ describe('send_message route', () => {
       };
     });
     const result = (await sendMessageRequest({
-      rootAgentId: 'foo',
       input: {
         content: '1',
         contentType: 'text',
@@ -81,7 +80,6 @@ describe('send_message route', () => {
       throw new Error('something went wrong');
     });
     const result = (await sendMessageRequest({
-      rootAgentId: 'foo',
       input: {
         content: '1',
         contentType: 'text',
@@ -111,7 +109,6 @@ describe('send_message route', () => {
       };
     });
     const result = (await sendMessageRequest({
-      rootAgentId: 'foo',
       input: {
         content: '1',
         contentType: 'text',
@@ -147,7 +144,6 @@ describe('send_message route', () => {
       };
     });
     const result = (await sendMessageRequest({
-      rootAgentId: 'foo',
       input: {
         content: '1',
         contentType: 'text',
@@ -180,7 +176,6 @@ describe('send_message route', () => {
       throw new Error('foo');
     });
     const result = (await sendMessageRequest({
-      rootAgentId: 'foo',
       input: {
         content: '1',
         contentType: 'text',

--- a/server/services/chat/olly_chat_service.mock.ts
+++ b/server/services/chat/olly_chat_service.mock.ts
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { PublicContract } from '@osd/utility-types';
 import { OllyChatService } from './olly_chat_service';
 
-const mockOllyChatService: jest.Mocked<OllyChatService> = {
+const mockOllyChatService: jest.Mocked<PublicContract<OllyChatService>> = {
   requestLLM: jest.fn(),
+  regenerate: jest.fn(),
   abortAgentExecution: jest.fn(),
 };
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -37,6 +37,7 @@ export interface MessageParser {
 
 export interface RoutesOptions {
   messageParsers: MessageParser[];
+  rootAgentId?: string;
 }
 
 declare module '../../../src/core/server' {

--- a/server/types.ts
+++ b/server/types.ts
@@ -6,8 +6,10 @@
 import { IMessage, Interaction } from '../common/types/chat_saved_object_attributes';
 import { Logger } from '../../../src/core/server';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface AssistantPluginSetup {}
+export interface AssistantPluginSetup {
+  registerMessageParser: (message: MessageParser) => void;
+  removeMessageParser: (parserId: MessageParser['id']) => void;
+}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AssistantPluginStart {}
 


### PR DESCRIPTION
### Description
For 2.12, we will store the root agent id into opensearch_dashboards.yml file and only cluster admin will be able to modify that.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
