### PR TITLE
fix: save to notebook toast content in next line

### DIFF
--- a/public/components/notebook/notebook_name_modal.tsx
+++ b/public/components/notebook/notebook_name_modal.tsx
@@ -41,14 +41,14 @@ export const NotebookNameModal = ({ onClose, saveChat }: NotebookNameModalProps)
       const notebookLink = `./observability-notebooks#/${notebookId}?view=view_both`;
 
       toasts.addSuccess({
-        text: toMountPoint(
-          <p>
+        title: toMountPoint(
+          <>
             This conversation was saved as{' '}
             <EuiLink href={notebookLink} target="_blank">
               {name}
             </EuiLink>
             .
-          </p>
+          </>
         ),
       });
     } catch (error) {


### PR DESCRIPTION
### Description
Move toast content to the same line with icon

Before:
<img width="486" alt="image" src="https://github.com/opensearch-project/dashboards-assistant/assets/4034161/d3083bad-9113-4121-995d-ea1b823caa89">


After:
<img width="499" alt="image" src="https://github.com/opensearch-project/dashboards-assistant/assets/4034161/72953260-57d1-4695-850c-87eea4191a3a">


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
