### PR TITLE
Search root agent id by rootAgentName specified in opensearch_dashboards.yml

### DIFF
--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -30,7 +30,7 @@ interface PublicConfig {
   chat: {
     // whether chat feature is enabled, UI should hide if false
     enabled: boolean;
-    rootAgentId?: string;
+    rootAgentName?: string;
   };
 }
 
@@ -75,7 +75,7 @@ export class AssistantPlugin
     const checkAccess = (account: Awaited<ReturnType<typeof getAccount>>) =>
       account.data.roles.some((role) => ['all_access', 'assistant_user'].includes(role));
 
-    if (this.config.chat.enabled && this.config.chat.rootAgentId) {
+    if (this.config.chat.enabled) {
       core.getStartServices().then(async ([coreStart, startDeps]) => {
         const CoreContext = createOpenSearchDashboardsReactContext<AssistantServices>({
           ...coreStart,

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,7 +17,7 @@ const assistantConfig = {
   schema: schema.object({
     chat: schema.object({
       enabled: schema.boolean({ defaultValue: false }),
-      rootAgentId: schema.maybe(schema.string()),
+      rootAgentName: schema.maybe(schema.string()),
     }),
   }),
 };

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -16,7 +16,7 @@ import { setupRoutes } from './routes/index';
 import { AssistantPluginSetup, AssistantPluginStart, MessageParser } from './types';
 import { BasicInputOutputParser } from './parsers/basic_input_output_parser';
 import { VisualizationCardParser } from './parsers/visualization_card_parser';
-import { AgentIdNotFoundError } from './routes/chat_routes';
+import { AgentNameNotFoundError } from './routes/chat_routes';
 
 export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPluginStart> {
   private readonly logger: Logger;
@@ -37,8 +37,8 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
      * Check if user enable the chat without specifying a root agent id.
      * If so, gives a warning for guidance.
      */
-    if (config.chat.enabled && !config.chat.rootAgentId) {
-      this.logger.warn(AgentIdNotFoundError);
+    if (config.chat.enabled && !config.chat.rootAgentName) {
+      this.logger.warn(AgentNameNotFoundError);
     }
 
     const router = core.http.createRouter();
@@ -53,7 +53,7 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
     // Register server side APIs
     setupRoutes(router, {
       messageParsers: this.messageParsers,
-      rootAgentId: config.chat.rootAgentId,
+      rootAgentName: config.chat.rootAgentName,
     });
 
     core.capabilities.registerProvider(() => ({

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -34,7 +34,7 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
       .toPromise();
 
     /**
-     * Check if user enable the chat without specifying a root agent id.
+     * Check if user enable the chat without specifying a root agent name.
      * If so, gives a warning for guidance.
      */
     if (config.chat.enabled && !config.chat.rootAgentName) {

--- a/server/routes/chat_routes.ts
+++ b/server/routes/chat_routes.ts
@@ -135,8 +135,8 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       context.core.opensearch.client.asCurrentUser,
       routeOptions.messageParsers
     );
-  const createChatService = (context: RequestHandlerContext) =>
-    new OllyChatService(context, routeOptions.rootAgentName!);
+  const createChatService = (context: RequestHandlerContext, rootAgentName: string) =>
+    new OllyChatService(context, rootAgentName);
 
   router.post(
     llmRequestRoute,
@@ -151,7 +151,7 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       }
       const { messages = [], input, sessionId: sessionIdInRequestBody } = request.body;
       const storageService = createStorageService(context);
-      const chatService = createChatService(context);
+      const chatService = createChatService(context, routeOptions.rootAgentName);
 
       let outputs: Awaited<ReturnType<ChatService['requestLLM']>> | undefined;
 
@@ -326,8 +326,7 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<HttpResponsePayload | ResponseError>> => {
-      const chatService = createChatService(context);
-
+      const chatService = createChatService(context, '');
       try {
         chatService.abortAgentExecution(request.body.sessionId);
         context.assistant_plugin.logger.info(`Abort agent execution: ${request.body.sessionId}`);
@@ -352,7 +351,7 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       }
       const { sessionId, interactionId } = request.body;
       const storageService = createStorageService(context);
-      const chatService = createChatService(context);
+      const chatService = createChatService(context, routeOptions.rootAgentName);
 
       let outputs: Awaited<ReturnType<ChatService['regenerate']>> | undefined;
 

--- a/server/routes/regenerate.test.ts
+++ b/server/routes/regenerate.test.ts
@@ -14,12 +14,12 @@ import {
 } from '../services/storage/agent_framework_storage_service.mock';
 import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';
 import { loggerMock } from '../../../../src/core/server/logging/logger.mock';
-import { registerChatRoutes, RegenerateSchema, AgentIdNotFoundError } from './chat_routes';
+import { registerChatRoutes, RegenerateSchema, AgentNameNotFoundError } from './chat_routes';
 import { ASSISTANT_API } from '../../common/constants/llm';
 
 const mockedLogger = loggerMock.create();
 
-describe('regenerate route when rootAgentId is provided', () => {
+describe('regenerate route when rootAgentName is provided', () => {
   const router = new Router(
     '',
     mockedLogger,
@@ -31,7 +31,7 @@ describe('regenerate route when rootAgentId is provided', () => {
   );
   registerChatRoutes(router, {
     messageParsers: [],
-    rootAgentId: 'foo',
+    rootAgentName: 'foo',
   });
   const regenerateRequest = (payload: RegenerateSchema) =>
     triggerHandler(router, {
@@ -169,7 +169,7 @@ describe('regenerate route when rootAgentId is provided', () => {
   });
 });
 
-describe('regenerate route when rootAgentId is not provided', () => {
+describe('regenerate route when rootAgentName is not provided', () => {
   const router = new Router(
     '',
     mockedLogger,
@@ -200,13 +200,13 @@ describe('regenerate route when rootAgentId is not provided', () => {
       sessionId: 'foo',
     })) as Boom;
     expect(mockedLogger.error).toBeCalledTimes(1);
-    expect(mockedLogger.error).toBeCalledWith(AgentIdNotFoundError);
+    expect(mockedLogger.error).toBeCalledWith(AgentNameNotFoundError);
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},
         "payload": Object {
           "error": "Bad Request",
-          "message": "rootAgentId is required, please specify one in opensearch_dashboards.yml",
+          "message": "rootAgentName is required, please specify one in opensearch_dashboards.yml",
           "statusCode": 400,
         },
         "statusCode": 400,

--- a/server/routes/send_message.test.ts
+++ b/server/routes/send_message.test.ts
@@ -14,12 +14,12 @@ import {
 } from '../services/storage/agent_framework_storage_service.mock';
 import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';
 import { loggerMock } from '../../../../src/core/server/logging/logger.mock';
-import { registerChatRoutes, LLMRequestSchema, AgentIdNotFoundError } from './chat_routes';
+import { registerChatRoutes, LLMRequestSchema, AgentNameNotFoundError } from './chat_routes';
 import { ASSISTANT_API } from '../../common/constants/llm';
 
 const mockedLogger = loggerMock.create();
 
-describe('send_message route when rootAgentId is provided', () => {
+describe('send_message route when rootAgentName is provided', () => {
   const router = new Router(
     '',
     mockedLogger,
@@ -31,7 +31,7 @@ describe('send_message route when rootAgentId is provided', () => {
   );
   registerChatRoutes(router, {
     messageParsers: [],
-    rootAgentId: 'foo',
+    rootAgentName: 'foo',
   });
   const sendMessageRequest = (payload: LLMRequestSchema) =>
     triggerHandler(router, {
@@ -265,7 +265,7 @@ describe('send_message route when rootAgentId is provided', () => {
   });
 });
 
-describe('send_message route when rootAgentId is not provided', () => {
+describe('send_message route when rootAgentName is not provided', () => {
   const router = new Router(
     '',
     mockedLogger,
@@ -303,13 +303,13 @@ describe('send_message route when rootAgentId is not provided', () => {
       sessionId: 'foo',
     })) as Boom;
     expect(mockedLogger.error).toBeCalledTimes(1);
-    expect(mockedLogger.error).toBeCalledWith(AgentIdNotFoundError);
+    expect(mockedLogger.error).toBeCalledWith(AgentNameNotFoundError);
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},
         "payload": Object {
           "error": "Bad Request",
-          "message": "rootAgentId is required, please specify one in opensearch_dashboards.yml",
+          "message": "rootAgentName is required, please specify one in opensearch_dashboards.yml",
           "statusCode": 400,
         },
         "statusCode": 400,

--- a/server/services/chat/olly_chat_service.ts
+++ b/server/services/chat/olly_chat_service.ts
@@ -7,7 +7,11 @@ import { ApiResponse } from '@opensearch-project/opensearch';
 import { RequestHandlerContext } from '../../../../../src/core/server';
 import { IMessage, IInput } from '../../../common/types/chat_saved_object_attributes';
 import { ChatService } from './chat_service';
-import { ML_COMMONS_BASE_API } from '../../utils/constants';
+import {
+  ML_COMMONS_BASE_API,
+  RESOURCE_NOT_FOUND_STATUS_CODE,
+  RESOURCE_NOT_FOUND_ERROR,
+} from '../../utils/constants';
 
 interface AgentRunPayload {
   question?: string;
@@ -21,22 +25,89 @@ const INTERACTION_ID_FIELD = 'parent_interaction_id';
 
 export class OllyChatService implements ChatService {
   static abortControllers: Map<string, AbortController> = new Map();
+  private static rootAgentId: string | undefined;
 
-  private async requestAgentRun(
-    rootAgentId: string,
-    payload: AgentRunPayload,
-    context: RequestHandlerContext
-  ) {
+  constructor(
+    private readonly context: RequestHandlerContext,
+    private readonly rootAgentName: string
+  ) { }
+
+  private async initRootAgent() {
+    OllyChatService.rootAgentId = await this.searchRootAgent(this.rootAgentName);
+  }
+
+  private async searchRootAgent(rootAgentName: string): Promise<string> {
+    try {
+      const requestParams = {
+        query: {
+          term: {
+            'name.keyword': rootAgentName,
+          },
+        },
+        sort: {
+          created_time: 'desc',
+        },
+      };
+
+      const opensearchClient = this.context.core.opensearch.client.asCurrentUser;
+      const response = await opensearchClient.transport.request({
+        method: 'GET',
+        path: `${ML_COMMONS_BASE_API}/agents/_search`,
+        body: requestParams,
+      });
+
+      if (!response || response.body.hits.total.value === 0) {
+        throw new Error('cannot find any root agent by name: ' + rootAgentName);
+      }
+      return response.body.hits.hits[0]._id;
+    } catch (error) {
+      let errorMessage = JSON.stringify(error.meta?.body);
+      if (!errorMessage) {
+        errorMessage = error.toString();
+      }
+      throw new Error('search root agent failed, reason: ' + errorMessage);
+    }
+  }
+
+  private async requestAgentRun(payload: AgentRunPayload) {
     if (payload.memory_id) {
       OllyChatService.abortControllers.set(payload.memory_id, new AbortController());
     }
-    const opensearchClient = context.core.opensearch.client.asCurrentUser;
 
+    // if rootAgentId has not been initialized yet, init rootAgentId firstly
+    if (!OllyChatService.rootAgentId) {
+      await this.initRootAgent();
+      this.context.assistant_plugin.logger.info(
+        `root agent id has not been initialized yet, init it at the first time, current root agent id is:${OllyChatService.rootAgentId}`
+      );
+    }
+
+    try {
+      return await this.callExecuteAgentAPI(payload);
+    } catch (error) {
+      if (
+        error.meta?.statusCode === RESOURCE_NOT_FOUND_STATUS_CODE &&
+        error.body.error.type === RESOURCE_NOT_FOUND_ERROR
+      ) {
+        const oldRootAgentId = OllyChatService.rootAgentId;
+        await this.initRootAgent();
+        this.context.assistant_plugin.logger.info(
+          `cannot find the root agent id: ${oldRootAgentId}, try to fetch the new root agent id, now it is:${OllyChatService.rootAgentId}`
+        );
+        return await this.callExecuteAgentAPI(payload);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  private async callExecuteAgentAPI(payload: AgentRunPayload) {
+    const opensearchClient = this.context.core.opensearch.client.asCurrentUser;
     try {
       const agentFrameworkResponse = (await opensearchClient.transport.request(
         {
           method: 'POST',
-          path: `${ML_COMMONS_BASE_API}/agents/${rootAgentId}/_execute`,
+          path: `${ML_COMMONS_BASE_API}/agents/${OllyChatService.rootAgentId}/_execute`,
           body: {
             parameters: payload,
           },
@@ -78,15 +149,16 @@ export class OllyChatService implements ChatService {
     }
   }
 
-  public async requestLLM(
-    payload: { messages: IMessage[]; input: IInput; sessionId?: string; rootAgentId: string },
-    context: RequestHandlerContext
-  ): Promise<{
+  public async requestLLM(payload: {
+    messages: IMessage[];
+    input: IInput;
+    sessionId?: string;
+  }): Promise<{
     messages: IMessage[];
     memoryId: string;
     interactionId: string;
   }> {
-    const { input, sessionId, rootAgentId } = payload;
+    const { input, sessionId } = payload;
 
     const parametersPayload: Pick<AgentRunPayload, 'question' | 'verbose' | 'memory_id'> = {
       question: input.content,
@@ -97,14 +169,13 @@ export class OllyChatService implements ChatService {
       parametersPayload.memory_id = sessionId;
     }
 
-    return await this.requestAgentRun(rootAgentId, parametersPayload, context);
+    return await this.requestAgentRun(parametersPayload);
   }
 
   async regenerate(
-    payload: { sessionId: string; interactionId: string; rootAgentId: string },
-    context: RequestHandlerContext
+    payload: { sessionId: string; interactionId: string; },
   ): Promise<{ messages: IMessage[]; memoryId: string; interactionId: string }> {
-    const { sessionId, interactionId, rootAgentId } = payload;
+    const { sessionId, interactionId } = payload;
     const parametersPayload: Pick<
       AgentRunPayload,
       'regenerate_interaction_id' | 'verbose' | 'memory_id'
@@ -114,12 +185,17 @@ export class OllyChatService implements ChatService {
       verbose: true,
     };
 
-    return await this.requestAgentRun(rootAgentId, parametersPayload, context);
+    return await this.requestAgentRun(parametersPayload);
   }
 
   abortAgentExecution(sessionId: string) {
     if (OllyChatService.abortControllers.has(sessionId)) {
       OllyChatService.abortControllers.get(sessionId)?.abort();
     }
+  }
+
+  // only used for test
+  public resetRootAgentId() {
+    OllyChatService.rootAgentId = undefined;
   }
 }

--- a/server/services/chat/olly_chat_service.ts
+++ b/server/services/chat/olly_chat_service.ts
@@ -30,7 +30,7 @@ export class OllyChatService implements ChatService {
   constructor(
     private readonly context: RequestHandlerContext,
     private readonly rootAgentName: string
-  ) { }
+  ) {}
 
   private async initRootAgent() {
     OllyChatService.rootAgentId = await this.searchRootAgent(this.rootAgentName);
@@ -61,10 +61,7 @@ export class OllyChatService implements ChatService {
       }
       return response.body.hits.hits[0]._id;
     } catch (error) {
-      let errorMessage = JSON.stringify(error.meta?.body);
-      if (!errorMessage) {
-        errorMessage = error.toString();
-      }
+      const errorMessage = JSON.stringify(error.meta?.body) || error;
       throw new Error('search root agent failed, reason: ' + errorMessage);
     }
   }
@@ -149,7 +146,7 @@ export class OllyChatService implements ChatService {
     }
   }
 
-  public async requestLLM(payload: {
+  async requestLLM(payload: {
     messages: IMessage[];
     input: IInput;
     sessionId?: string;
@@ -172,9 +169,10 @@ export class OllyChatService implements ChatService {
     return await this.requestAgentRun(parametersPayload);
   }
 
-  async regenerate(
-    payload: { sessionId: string; interactionId: string; },
-  ): Promise<{ messages: IMessage[]; memoryId: string; interactionId: string }> {
+  async regenerate(payload: {
+    sessionId: string;
+    interactionId: string;
+  }): Promise<{ messages: IMessage[]; memoryId: string; interactionId: string }> {
     const { sessionId, interactionId } = payload;
     const parametersPayload: Pick<
       AgentRunPayload,
@@ -195,7 +193,7 @@ export class OllyChatService implements ChatService {
   }
 
   // only used for test
-  public resetRootAgentId() {
+  resetRootAgentId() {
     OllyChatService.rootAgentId = undefined;
   }
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -40,7 +40,7 @@ export interface MessageParser {
 
 export interface RoutesOptions {
   messageParsers: MessageParser[];
-  rootAgentId?: string;
+  rootAgentName?: string;
 }
 
 declare module '../../../src/core/server' {

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -4,3 +4,5 @@
  */
 
 export const ML_COMMONS_BASE_API = '/_plugins/_ml';
+export const RESOURCE_NOT_FOUND_STATUS_CODE = 404;
+export const RESOURCE_NOT_FOUND_ERROR = 'resource_not_found_exception';


### PR DESCRIPTION
### Description
This PR aims to change the behavior of getting root agent id, users have to specify the name of the root agent in the yml, and when they send the first message in the chat box, the node server will call the search agent api in ml-commons to get the root agent id, if multiple root agents are found, we only fetch the latest one. 

This PR also lets users to change the root agent dynamically, they can delete the old root agent firstly and create a new one with the old name,  when sending message, the api in backend will throw 404 error with message `resource_not_found_exception`, this time the node server will retry to search the root agent by the specified name, if found, the new root agent id will be used and cached.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
