### PR TITLE
fix: disable top input when no access

### DIFF
--- a/public/chat_header_button.test.tsx
+++ b/public/chat_header_button.test.tsx
@@ -159,4 +159,39 @@ describe('<HeaderChatButton />', () => {
     });
     expect(screen.getByLabelText('chat input')).toHaveFocus();
   });
+
+  it('should disable chat input when no access', () => {
+    render(
+      <HeaderChatButton
+        application={applicationServiceMock.createStartContract()}
+        userHasAccess={false}
+        contentRenderers={{}}
+        actionExecutors={{}}
+        assistantActions={{} as AssistantActions}
+        currentAccount={{ username: 'test_user', tenant: 'test_tenant' }}
+      />
+    );
+    expect(screen.getByLabelText('chat input')).toBeDisabled();
+  });
+
+  it('should not focus on chat input when no access and pressing global shortcut', () => {
+    render(
+      <HeaderChatButton
+        application={applicationServiceMock.createStartContract()}
+        userHasAccess={false}
+        contentRenderers={{}}
+        actionExecutors={{}}
+        assistantActions={{} as AssistantActions}
+        currentAccount={{ username: 'test_user', tenant: 'test_tenant' }}
+      />
+    );
+    expect(screen.getByLabelText('chat input')).not.toHaveFocus();
+    fireEvent.keyDown(document.body, {
+      key: '/',
+      code: 'NumpadDivide',
+      charCode: 111,
+      metaKey: true,
+    });
+    expect(screen.getByLabelText('chat input')).not.toHaveFocus();
+  });
 });

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -124,6 +124,9 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
   };
 
   useEffect(() => {
+    if (!props.userHasAccess) {
+      return;
+    }
     const onGlobalMouseUp = (e: KeyboardEvent) => {
       if (e.metaKey && e.key === '/') {
         inputRef.current?.focus();
@@ -134,7 +137,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
     return () => {
       document.removeEventListener('keydown', onGlobalMouseUp);
     };
-  }, []);
+  }, [props.userHasAccess]);
 
   return (
     <>
@@ -179,6 +182,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
               )}
             </span>
           }
+          disabled={!props.userHasAccess}
         />
       </div>
       <ChatContext.Provider value={chatContextValue}>


### PR DESCRIPTION
### Description
Disable top input when user no access

Before:
<img width="513" alt="image" src="https://github.com/opensearch-project/dashboards-assistant/assets/4034161/00d65b1a-b7ff-4c95-ba28-5e0f80d986bd">


After:
<img width="590" alt="image" src="https://github.com/opensearch-project/dashboards-assistant/assets/4034161/ff564d8d-2324-403e-a694-accd5785d915">


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
