### PR TITLE
fix: bypass real error info from backend

### DIFF
--- a/server/routes/chat_routes.ts
+++ b/server/routes/chat_routes.ts
@@ -167,7 +167,7 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       } catch (error) {
         context.assistant_plugin.logger.error(error);
         const sessionId = outputs?.memoryId || sessionIdInRequestBody;
-        if (!sessionId) {
+        if (!sessionId || !outputs?.interactionId) {
           return response.custom({ statusCode: error.statusCode || 500, body: error.message });
         }
       }

--- a/server/routes/chat_routes.ts
+++ b/server/routes/chat_routes.ts
@@ -166,10 +166,7 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
         });
       } catch (error) {
         context.assistant_plugin.logger.error(error);
-        const sessionId = outputs?.memoryId || sessionIdInRequestBody;
-        if (!sessionId || !outputs?.interactionId) {
-          return response.custom({ statusCode: error.statusCode || 500, body: error.message });
-        }
+        return response.custom({ statusCode: error.statusCode || 500, body: error.message });
       }
 
       /**

--- a/server/routes/send_message.test.ts
+++ b/server/routes/send_message.test.ts
@@ -183,7 +183,7 @@ describe('send_message route when rootAgentName is provided', () => {
     `);
   });
 
-  it('return successfully when requestLLM throws an error but conversation id provided', async () => {
+  it('throw error when requestLLM throws an error and interaction id is not provided', async () => {
     mockOllyChatService.requestLLM.mockImplementationOnce(() => {
       throw new Error('something went wrong');
     });
@@ -209,21 +209,17 @@ describe('send_message route when rootAgentName is provided', () => {
         },
       },
       sessionId: 'foo',
-    })) as ResponseObject;
+    })) as Boom;
     expect(mockedLogger.error).toBeCalledWith(new Error('something went wrong'));
-    expect(result.source).toMatchInlineSnapshot(`
+    expect(result.output).toMatchInlineSnapshot(`
       Object {
-        "interactions": Array [
-          Object {
-            "conversation_id": "foo",
-            "create_time": "create_time",
-            "input": "foo",
-            "interaction_id": "interaction_id",
-            "response": "bar",
-          },
-        ],
-        "messages": Array [],
-        "sessionId": "foo",
+        "headers": Object {},
+        "payload": Object {
+          "error": "Internal Server Error",
+          "message": "something went wrong",
+          "statusCode": 500,
+        },
+        "statusCode": 500,
       }
     `);
   });

--- a/server/routes/send_message.test.ts
+++ b/server/routes/send_message.test.ts
@@ -183,7 +183,7 @@ describe('send_message route when rootAgentName is provided', () => {
     `);
   });
 
-  it('throw error when requestLLM throws an error and interaction id is not provided', async () => {
+  it('throw error when requestLLM throws an error', async () => {
     mockOllyChatService.requestLLM.mockImplementationOnce(() => {
       throw new Error('something went wrong');
     });


### PR DESCRIPTION
### Description
Bypass error from _execute API to better debug and find root cause.
#### Before:
![image](https://github.com/opensearch-project/dashboards-assistant/assets/13493605/ff9213fc-72a2-4ea8-a512-2c5890a504d9)


#### After:
![image](https://github.com/opensearch-project/dashboards-assistant/assets/13493605/f3049c81-27e1-433d-9de6-86faa0642851)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
