### PR TITLE
manually set version of 2.x to 2.12

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "assistantDashboards",
-  "version": "3.0.0.0",
-  "opensearchDashboardsVersion": "3.0.0",
+  "version": "2.12.0.0",
+  "opensearchDashboardsVersion": "2.12.0",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assistant-dashboards",
-  "version": "3.0.0.0",
+  "version": "2.12.0.0",
   "main": "index.ts",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
### Description
The auto workflow set to 2.12 has been missed .Manually set version of 2.x branch to 2.12.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
