### PR TITLE
Refactor find last methods

### DIFF
--- a/public/hooks/use_chat_actions.tsx
+++ b/public/hooks/use_chat_actions.tsx
@@ -5,6 +5,7 @@
 
 import { TAB_ID } from '../utils/constants';
 import { ASSISTANT_API } from '../../common/constants/llm';
+import { findLastIndex } from '../utils';
 import {
   IMessage,
   ISuggestedAction,
@@ -187,7 +188,8 @@ export const useChatActions = (): AssistantActions => {
          * In implementation of Agent framework, it will generate a new interactionId
          * so need to remove the staled interaction in Frontend manually.
          */
-        const findRegeratedMessageIndex = chatState.messages.findLastIndex(
+        const findRegeratedMessageIndex = findLastIndex(
+          chatState.messages,
           (message) => message.type === 'input'
         );
         if (findRegeratedMessageIndex > -1) {

--- a/public/hooks/use_chat_state.tsx
+++ b/public/hooks/use_chat_state.tsx
@@ -6,6 +6,7 @@
 import { produce } from 'immer';
 import React, { useContext, useMemo, useReducer } from 'react';
 import { IMessage, Interaction } from '../../common/types/chat_saved_object_attributes';
+import { findLastIndex } from '../utils';
 
 export interface ChatState {
   messages: IMessage[];
@@ -104,7 +105,7 @@ const chatStateReducer: React.Reducer<ChatState, ChatStateAction> = (state, acti
         draft.llmResponding = false;
         break;
       case 'regenerate':
-        const lastInputIndex = draft.messages.findLastIndex((msg) => msg.type === 'input');
+        const lastInputIndex = findLastIndex(draft.messages, (msg) => msg.type === 'input');
         // Exclude the last outputs
         draft.messages = draft.messages.slice(0, lastInputIndex + 1);
         draft.llmResponding = true;

--- a/public/hooks/use_feed_back.tsx
+++ b/public/hooks/use_feed_back.tsx
@@ -25,7 +25,8 @@ export const useFeedback = (interaction?: Interaction | null) => {
     });
     const inputMessage = chatState.messages
       .slice(0, outputMessageIndex)
-      .findLast((item) => item.type === 'input');
+      .reverse()
+      .find((item) => item.type === 'input');
     if (!inputMessage) {
       return;
     }

--- a/public/tabs/chat/chat_page_content.tsx
+++ b/public/tabs/chat/chat_page_content.tsx
@@ -22,6 +22,7 @@ import {
 import { WelcomeMessage } from '../../components/chat_welcome_message';
 import { useChatContext } from '../../contexts';
 import { useChatState, useChatActions } from '../../hooks';
+import { findLastIndex } from '../../utils';
 import { MessageBubble } from './messages/message_bubble';
 import { MessageContent } from './messages/message_content';
 import { SuggestionBubble } from './suggestions/suggestion_bubble';
@@ -81,7 +82,7 @@ export const ChatPageContent: React.FC<ChatPageContentProps> = React.memo((props
   }
 
   const firstInputIndex = chatState.messages.findIndex((msg) => msg.type === 'input');
-  const lastInputIndex = chatState.messages.findLastIndex((msg) => msg.type === 'input');
+  const lastInputIndex = findLastIndex(chatState.messages, (msg) => msg.type === 'input');
 
   return (
     <>

--- a/public/utils/find_last_index.ts
+++ b/public/utils/find_last_index.ts
@@ -10,9 +10,10 @@ export const findLastIndex = <T>(
   if (array.length === 0) {
     return -1;
   }
-  const index = [...array].reverse().findIndex(predicate);
-  if (index === -1) {
-    return -1;
+  for (let i = array.length - 1; i >= 0; i--) {
+    if (predicate(array[i], i, array)) {
+      return i;
+    }
   }
-  return array.length - index - 1;
+  return -1;
 };

--- a/public/utils/find_last_index.ts
+++ b/public/utils/find_last_index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const findLastIndex = <T>(
+  array: T[],
+  predicate: (value: T, index: number, array: T[]) => unknown
+) => {
+  if (array.length === 0) {
+    return -1;
+  }
+  const index = [...array].reverse().findIndex(predicate);
+  if (index === -1) {
+    return -1;
+  }
+  return array.length - index - 1;
+};

--- a/public/utils/index.ts
+++ b/public/utils/index.ts
@@ -4,3 +4,4 @@
  */
 
 export * from './notebook';
+export * from './find_last_index';

--- a/public/utils/tests/find_last_index.test.ts
+++ b/public/utils/tests/find_last_index.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { findLastIndex } from '../find_last_index';
+
+describe('findLastIndex should return consistent value', () => {
+  it('should return -1 if element not found', () => {
+    expect(findLastIndex([1, 2, 3, 3, 4], (item) => item === 5)).toBe(-1);
+    expect(findLastIndex([], () => true)).toBe(-1);
+  });
+  it('should return consistent index if element found', () => {
+    expect(findLastIndex([1, 2, 3, 4], (item) => item === 3)).toBe(2);
+    expect(findLastIndex([1, 2, 3, 3, 4], (item) => item === 3)).toBe(3);
+    expect(findLastIndex([1, 2, 3, 4, 4], (item) => item === 4)).toBe(4);
+    expect(findLastIndex([1, 1, 2, 3, 4], (item) => item === 1)).toBe(1);
+  });
+});


### PR DESCRIPTION
### Description
Find last related methods was added in [TC39](https://github.com/tc39/proposal-array-find-from-last), it can't be used in some [old browsers](https://caniuse.com/?search=findLast). The FT for electron 94 in FT repo will be failed due to these methods. Refactor to reverse and find.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
