### PR TITLE
fix minutes format in conversation history list

### DIFF
--- a/public/tabs/history/__tests__/chat_history_list.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_list.test.tsx
@@ -21,8 +21,8 @@ describe('<ChatHistoryList />', () => {
 
     expect(getByText('foo')).toBeInTheDocument();
     expect(getByText('bar')).toBeInTheDocument();
-    expect(getByText('January 1, 1970 at 12:0 AM')).toBeInTheDocument();
-    expect(getByText('January 1, 1970 at 12:6 AM')).toBeInTheDocument();
+    expect(getByText('January 1, 1970 at 12:00 AM')).toBeInTheDocument();
+    expect(getByText('January 1, 1970 at 12:06 AM')).toBeInTheDocument();
     expect(getAllByLabelText('history horizontal rule')).toHaveLength(1);
   });
 

--- a/public/tabs/history/chat_history_list.tsx
+++ b/public/tabs/history/chat_history_list.tsx
@@ -69,7 +69,7 @@ export const ChatHistoryListItem = ({
           </EuiLink>
           <EuiText size="s" color="subdued">
             {moment(updatedTimeMs).format('MMMM D, YYYY')} at{' '}
-            {moment(updatedTimeMs).format('h:m A')}
+            {moment(updatedTimeMs).format('h:mm A')}
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>


### PR DESCRIPTION
### Description
#### Before
![image](https://github.com/opensearch-project/dashboards-assistant/assets/4034161/73df67f4-8fd5-4baa-be03-b46662a2b622)
#### After
![image](https://github.com/opensearch-project/dashboards-assistant/assets/4034161/b2e20c44-c245-4a86-b0eb-727407af119b)
Change minutes format to "mm"

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
