### PR TITLE
change view trace from suggestions to message action bar

### DIFF
--- a/common/types/chat_saved_object_attributes.ts
+++ b/common/types/chat_saved_object_attributes.ts
@@ -71,7 +71,7 @@ export type ISuggestedAction = ISuggestedActionBase &
       }
     | {
         actionType: 'view_trace';
-        metadata: { interactionId: string; icon: string };
+        metadata: { interactionId: string };
       }
   );
 export interface SendFeedbackBody {

--- a/public/tabs/chat/chat_page_content.test.tsx
+++ b/public/tabs/chat/chat_page_content.test.tsx
@@ -222,29 +222,6 @@ describe('<ChatPageContent />', () => {
     expect(abortActionMock).toHaveBeenCalledWith('test_conversation_id');
   });
 
-  it('should display `How was this generated?`', () => {
-    const messages: IMessage[] = [
-      {
-        type: 'input',
-        content: 'what indices are in my cluster?',
-        contentType: 'text',
-      },
-      {
-        type: 'output',
-        content: 'here are the indices in your cluster: .kibana',
-        contentType: 'markdown',
-        suggestedActions: [],
-        interactionId: 'interaction_id_mock',
-      },
-    ];
-    jest.spyOn(chatStateHookExports, 'useChatState').mockReturnValue({
-      chatState: { messages, llmResponding: false, interactions: [] },
-      chatStateDispatch: jest.fn(),
-    });
-    render(<ChatPageContent messagesLoading={false} onRefresh={jest.fn()} />);
-    expect(screen.queryByText('How was this generated?')).toBeInTheDocument();
-  });
-
   it('should call executeAction', () => {
     render(<ChatPageContent messagesLoading={false} onRefresh={jest.fn()} />);
     fireEvent.click(screen.getByText('What are the indices in my cluster?'));

--- a/public/tabs/chat/chat_page_content.tsx
+++ b/public/tabs/chat/chat_page_content.tsx
@@ -211,14 +211,6 @@ const Suggestions: React.FC<SuggestionsProps> = (props) => {
   const interactionId = props.message.interactionId;
 
   const suggestedActions = structuredClone(props.message.suggestedActions) || [];
-  if (interactionId) {
-    const viewTraceAction: ISuggestedAction = {
-      actionType: 'view_trace',
-      metadata: { interactionId, icon: 'questionInCircle' },
-      message: 'How was this generated?',
-    };
-    suggestedActions.push(viewTraceAction);
-  }
 
   if (!suggestedActions.length) {
     return null;
@@ -251,7 +243,6 @@ const Suggestions: React.FC<SuggestionsProps> = (props) => {
                   }
                   color={props.inputDisabled ? 'subdued' : 'default'}
                   content={suggestedAction.message}
-                  iconType={suggestedAction.metadata?.icon}
                 />
               </EuiFlexItem>
             </div>

--- a/public/tabs/chat/messages/message_bubble.test.tsx
+++ b/public/tabs/chat/messages/message_bubble.test.tsx
@@ -13,6 +13,7 @@ import * as useChatActionsExports from '../../../hooks/use_chat_actions';
 
 describe('<MessageBubble />', () => {
   const sendFeedbackMock = jest.fn();
+  const executeActionMock = jest.fn();
 
   beforeEach(() => {
     jest
@@ -23,7 +24,7 @@ describe('<MessageBubble />', () => {
       send: jest.fn(),
       loadChat: jest.fn(),
       openChatUI: jest.fn(),
-      executeAction: jest.fn(),
+      executeAction: executeActionMock,
       abortAction: jest.fn(),
       regenerate: jest.fn(),
     });
@@ -256,6 +257,8 @@ describe('<MessageBubble />', () => {
       />
     );
     expect(screen.getByTestId('trace-icon-bar')).toBeVisible();
+    fireEvent.click(screen.getByTestId('trace-icon-bar'));
+    expect(executeActionMock).toHaveBeenCalledTimes(1);
   });
 
   it('should NOT display action: view trace', () => {

--- a/public/tabs/chat/messages/message_bubble.test.tsx
+++ b/public/tabs/chat/messages/message_bubble.test.tsx
@@ -9,6 +9,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MessageBubble } from './message_bubble';
 import { IOutput } from '../../../../common/types/chat_saved_object_attributes';
 import * as useFeedbackHookExports from '../../../hooks/use_feed_back';
+import * as useChatActionsExports from '../../../hooks/use_chat_actions';
 
 describe('<MessageBubble />', () => {
   const sendFeedbackMock = jest.fn();
@@ -17,6 +18,15 @@ describe('<MessageBubble />', () => {
     jest
       .spyOn(useFeedbackHookExports, 'useFeedback')
       .mockReturnValue({ feedbackResult: undefined, sendFeedback: sendFeedbackMock });
+
+    jest.spyOn(useChatActionsExports, 'useChatActions').mockReturnValue({
+      send: jest.fn(),
+      loadChat: jest.fn(),
+      openChatUI: jest.fn(),
+      executeAction: jest.fn(),
+      abortAction: jest.fn(),
+      regenerate: jest.fn(),
+    });
   });
 
   afterEach(() => {
@@ -223,5 +233,43 @@ describe('<MessageBubble />', () => {
     render(<MessageBubble showActionBar={true} message={message} />);
     fireEvent.click(screen.getByLabelText('feedback thumbs up'));
     expect(sendFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('should display action: view trace', () => {
+    render(
+      <MessageBubble
+        showActionBar={true}
+        showRegenerate={true}
+        message={{
+          type: 'output',
+          contentType: 'markdown',
+          content: 'here are the indices in your cluster: .alert',
+          interactionId: 'bar',
+        }}
+        interaction={{
+          input: 'foo',
+          response: 'bar',
+          conversation_id: 'foo',
+          interaction_id: 'bar',
+          create_time: new Date().toLocaleString(),
+        }}
+      />
+    );
+    expect(screen.getByTestId('trace-icon-bar')).toBeVisible();
+  });
+
+  it('should NOT display action: view trace', () => {
+    render(
+      <MessageBubble
+        showActionBar={true}
+        showRegenerate={false}
+        message={{
+          type: 'output',
+          contentType: 'markdown',
+          content: 'here are the indices in your cluster: .alert',
+        }}
+      />
+    );
+    expect(screen.queryByTestId('trace-icon-bar')).toBeNull();
   });
 });

--- a/public/tabs/chat/messages/message_bubble.tsx
+++ b/public/tabs/chat/messages/message_bubble.tsx
@@ -19,10 +19,12 @@ import React, { useCallback } from 'react';
 import { IconType } from '@elastic/eui/src/components/icon/icon';
 import cx from 'classnames';
 // TODO: Replace with getChrome().logos.Chat.url
+import { useChatActions } from '../../../hooks';
 import chatIcon from '../../../assets/chat.svg';
 import {
   IMessage,
   IOutput,
+  ISuggestedAction,
   Interaction,
 } from '../../../../common/types/chat_saved_object_attributes';
 import { useFeedback } from '../../../hooks/use_feed_back';
@@ -46,6 +48,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
   const { feedbackResult, sendFeedback } = useFeedback(
     'interaction' in props ? props.interaction : null
   );
+
+  const { executeAction } = useChatActions();
 
   // According to the design of the feedback, only markdown type output is supported.
   const showFeedback =
@@ -227,6 +231,29 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
                     ) : null}
                   </>
                 )}
+                {props.message.interactionId ? (
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonIcon
+                      aria-label="How was this generated?"
+                      data-test-subj={`trace-icon-${props.message.interactionId}`}
+                      onClick={() => {
+                        const message = props.message as IOutput;
+
+                        const viewTraceAction: ISuggestedAction = {
+                          actionType: 'view_trace',
+                          metadata: {
+                            interactionId: message.interactionId || '',
+                          },
+                          message: 'How was this generated?',
+                        };
+                        executeAction(viewTraceAction, message);
+                      }}
+                      title="How was this generated?"
+                      color="text"
+                      iconType="iInCircle"
+                    />
+                  </EuiFlexItem>
+                ) : null}
               </EuiFlexGroup>
             </>
           )}


### PR DESCRIPTION
### Description
change view trace from suggestions to message action bar

show view trace icon on each message
![image](https://github.com/opensearch-project/dashboards-assistant/assets/113890546/415192e6-a56b-4f11-973b-63a7668f5a23)

how was it generated? been removed from suggestions list and moved to action bar
![image](https://github.com/opensearch-project/dashboards-assistant/assets/113890546/5ebe2c6d-2617-45c8-a43b-f2a55fef5596)



### Issues Resolved
#155 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
