### PR TITLE
Bypass response from backend APIs

### DIFF
--- a/server/services/storage/agent_framework_storage_service.test.ts
+++ b/server/services/storage/agent_framework_storage_service.test.ts
@@ -334,9 +334,13 @@ describe('AgentFrameworkStorageService', () => {
     mockedTransport.mockImplementationOnce(async (params) => {
       return Promise.reject({ meta: { body: 'error' } });
     });
-    expect(agentFrameworkService.getTraces('foo')).rejects.toMatchInlineSnapshot(
-      `[Error: get traces failed, reason:"error"]`
-    );
+    expect(agentFrameworkService.getTraces('foo')).rejects.toMatchInlineSnapshot(`
+      Object {
+        "meta": Object {
+          "body": "error",
+        },
+      }
+    `);
   });
 
   it('should encode id when calls getTraces with non-standard params in request payload', async () => {
@@ -408,7 +412,13 @@ describe('AgentFrameworkStorageService', () => {
           bar: 'foo',
         },
       })
-    ).rejects.toMatchInlineSnapshot(`[Error: update interaction failed, reason:"error"]`);
+    ).rejects.toMatchInlineSnapshot(`
+      Object {
+        "meta": Object {
+          "body": "error",
+        },
+      }
+    `);
   });
 
   it('should encode id when calls updateInteraction with non-standard params in request payload', async () => {

--- a/server/services/storage/agent_framework_storage_service.ts
+++ b/server/services/storage/agent_framework_storage_service.ts
@@ -146,24 +146,20 @@ export class AgentFrameworkStorageService implements StorageService {
   }
 
   async deleteConversation(conversationId: string): Promise<ConversationOptResponse> {
-    try {
-      const response = await this.client.transport.request({
-        method: 'DELETE',
-        path: `${ML_COMMONS_BASE_API}/memory/${encodeURIComponent(conversationId)}`,
-      });
-      if (response.statusCode === 200) {
-        return {
-          success: true,
-        };
-      } else {
-        return {
-          success: false,
-          statusCode: response.statusCode,
-          message: JSON.stringify(response.body),
-        };
-      }
-    } catch (error) {
-      throw new Error('delete conversation failed, reason:' + JSON.stringify(error.meta?.body));
+    const response = await this.client.transport.request({
+      method: 'DELETE',
+      path: `${ML_COMMONS_BASE_API}/memory/${encodeURIComponent(conversationId)}`,
+    });
+    if (response.statusCode === 200) {
+      return {
+        success: true,
+      };
+    } else {
+      return {
+        success: false,
+        statusCode: response.statusCode,
+        message: JSON.stringify(response.body),
+      };
     }
   }
 
@@ -171,84 +167,72 @@ export class AgentFrameworkStorageService implements StorageService {
     conversationId: string,
     title: string
   ): Promise<ConversationOptResponse> {
-    try {
-      const response = await this.client.transport.request({
-        method: 'PUT',
-        path: `${ML_COMMONS_BASE_API}/memory/${encodeURIComponent(conversationId)}`,
-        body: {
-          name: title,
-        },
-      });
-      if (response.statusCode === 200) {
-        return {
-          success: true,
-        };
-      } else {
-        return {
-          success: false,
-          statusCode: response.statusCode,
-          message: JSON.stringify(response.body),
-        };
-      }
-    } catch (error) {
-      throw new Error('update conversation failed, reason:' + JSON.stringify(error.meta?.body));
+    const response = await this.client.transport.request({
+      method: 'PUT',
+      path: `${ML_COMMONS_BASE_API}/memory/${encodeURIComponent(conversationId)}`,
+      body: {
+        name: title,
+      },
+    });
+    if (response.statusCode === 200) {
+      return {
+        success: true,
+      };
+    } else {
+      return {
+        success: false,
+        statusCode: response.statusCode,
+        message: JSON.stringify(response.body),
+      };
     }
   }
 
   async getTraces(interactionId: string): Promise<AgentFrameworkTrace[]> {
-    try {
-      const response = (await this.client.transport.request({
-        method: 'GET',
-        path: `${ML_COMMONS_BASE_API}/memory/message/${encodeURIComponent(interactionId)}/traces`,
-      })) as ApiResponse<{
-        traces: Array<{
-          message_id: string;
-          create_time: string;
-          input: string;
-          response: string;
-          origin: string;
-          trace_number: number;
-        }>;
+    const response = (await this.client.transport.request({
+      method: 'GET',
+      path: `${ML_COMMONS_BASE_API}/memory/message/${encodeURIComponent(interactionId)}/traces`,
+    })) as ApiResponse<{
+      traces: Array<{
+        message_id: string;
+        create_time: string;
+        input: string;
+        response: string;
+        origin: string;
+        trace_number: number;
       }>;
+    }>;
 
-      return response.body.traces.map((item) => ({
-        interactionId: item.message_id,
-        input: item.input,
-        output: item.response,
-        createTime: item.create_time,
-        origin: item.origin,
-        traceNumber: item.trace_number,
-      }));
-    } catch (error) {
-      throw new Error('get traces failed, reason:' + JSON.stringify(error.meta?.body));
-    }
+    return response.body.traces.map((item) => ({
+      interactionId: item.message_id,
+      input: item.input,
+      output: item.response,
+      createTime: item.create_time,
+      origin: item.origin,
+      traceNumber: item.trace_number,
+    }));
   }
 
   async updateInteraction(
     interactionId: string,
     additionalInfo: Record<string, Record<string, boolean | string>>
   ): Promise<ConversationOptResponse> {
-    try {
-      const response = await this.client.transport.request({
-        method: 'PUT',
-        path: `${ML_COMMONS_BASE_API}/memory/message/${encodeURIComponent(interactionId)}`,
-        body: {
-          additional_info: additionalInfo,
-        },
-      });
-      if (response.statusCode === 200) {
-        return {
-          success: true,
-        };
-      } else {
-        return {
-          success: false,
-          statusCode: response.statusCode,
-          message: JSON.stringify(response.body),
-        };
-      }
-    } catch (error) {
-      throw new Error('update interaction failed, reason:' + JSON.stringify(error.meta?.body));
+    const response = await this.client.transport.request({
+      method: 'PUT',
+      path: `${ML_COMMONS_BASE_API}/memory/message/${encodeURIComponent(interactionId)}`,
+      body: {
+        additional_info: additionalInfo,
+      },
+    });
+    if (response.statusCode === 200) {
+      return {
+        success: true,
+      };
+    } else {
+      return {
+        success: false,
+        statusCode: response.statusCode,
+        message: JSON.stringify(response.body),
+      };
     }
   }
 


### PR DESCRIPTION
### Description
Remove duplicate `try catch` in `server/services/storage/agent_framework_storage_service.ts` to bypass backend status code and message.

- [x] deleteConversation
- [x] updateConversation
- [x] getTraces
- [x] updateInteraction

All the methods are wrapped by try catch in router.ts file, so it is safe to remove the unnecessary `try catch`.

#### Before
```
{
  "statusCode": 500,
  "error": "Internal Server Error",
  "message": "get traces failed, reason:{\"error\":{\"root_cause\":[{\"type\":\"resource_not_found_exception\",\"reason\":\"Interaction [${ ] not found\"}],\"type\":\"resource_not_found_exception\",\"reason\":\"Interaction [${ ] not found\"},\"status\":404}"
}
```

#### After
```
{"statusCode":404,"error":"Not Found","message":"Not Found"}
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [x] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
