### PR TITLE
Refactor with getDefaultDataSourceId$

### DIFF
--- a/public/services/__tests__/data_source_service.test.ts
+++ b/public/services/__tests__/data_source_service.test.ts
@@ -8,7 +8,7 @@ import { first } from 'rxjs/operators';
 
 import { uiSettingsServiceMock } from '../../../../../src/core/public/mocks';
 import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
-import { DataSourceManagementPluginSetup } from '../../types';
+import { DataSourceManagementPluginSetup } from '../../../../../src/plugins/data_source_management/public';
 import { DataSourceService } from '../data_source_service';
 
 const setup = (options?: {
@@ -24,10 +24,10 @@ const setup = (options?: {
     dataSourceSelection: {
       getSelection$: () => dataSourceSelection$,
     },
+    getDefaultDataSourceId$: jest.fn(() => defaultDataSourceSelection$),
   };
   const dataSource = new DataSourceService();
   const defaultDataSourceSelection$ = new BehaviorSubject(options?.defaultDataSourceId ?? null);
-  uiSettings.get$.mockReturnValue(defaultDataSourceSelection$);
   const setupResult = dataSource.setup({
     uiSettings,
     dataSourceManagement:

--- a/public/services/data_source_service.ts
+++ b/public/services/data_source_service.ts
@@ -8,7 +8,7 @@ import { first, map } from 'rxjs/operators';
 
 import type { IUiSettingsClient } from '../../../../src/core/public';
 import type { DataSourceOption } from '../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
-import type { DataSourceManagementPluginSetup } from '../types';
+import { DataSourceManagementPluginSetup } from '../../../../src/plugins/data_source_management/public';
 
 export enum DataSourceIdFrom {
   UiSettings,
@@ -83,7 +83,7 @@ export class DataSourceService {
   getDataSourceId$() {
     return combineLatest([
       this.dataSourceId$,
-      this.uiSettings?.get$('defaultDataSource', null) ?? of(null),
+      this.dataSourceManagement?.getDefaultDataSourceId$?.(this.uiSettings) ?? of(null),
     ]).pipe(
       map(([selectedDataSourceId, defaultDataSourceId]) => {
         if (selectedDataSourceId !== null) {

--- a/public/types.ts
+++ b/public/types.ts
@@ -3,21 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { BehaviorSubject } from 'rxjs';
 import { DashboardStart } from '../../../src/plugins/dashboard/public';
 import { EmbeddableSetup, EmbeddableStart } from '../../../src/plugins/embeddable/public';
 import { IMessage, ISuggestedAction } from '../common/types/chat_saved_object_attributes';
 import { IChatContext } from './contexts/chat_context';
 import { MessageContentProps } from './tabs/chat/messages/message_content';
 import { DataSourceServiceContract, IncontextInsightRegistry } from './services';
-import { DataSourceOption } from '../../../src/plugins/data_source_management/public';
-
-// TODO: should replace from DataSourceManagementPluginSetup in DSM plugin after data selection merged
-export interface DataSourceManagementPluginSetup {
-  dataSourceSelection?: {
-    getSelection$: () => BehaviorSubject<Map<string, DataSourceOption[]>>;
-  };
-}
+import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 
 export interface RenderProps {
   props: MessageContentProps;


### PR DESCRIPTION
### Description
Refactor default data source with getDefaultDataSource$ in dataSourceManagement.

### Issues Resolved
A part of #192 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
