### PR TITLE
Add feature flag to control query assistant like features

### DIFF
--- a/common/types/config.ts
+++ b/common/types/config.ts
@@ -14,6 +14,9 @@ export const configSchema = schema.object({
   incontextInsight: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),
+  next: schema.object({
+    enabled: schema.boolean({ defaultValue: false }),
+  }),
 });
 
 export type ConfigSchema = TypeOf<typeof configSchema>;

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -147,6 +147,7 @@ export class AssistantPlugin
         actionExecutors[actionType] = execute;
       },
       chatEnabled: () => this.config.chat.enabled,
+      nextEnabled: () => this.config.next.enabled,
       assistantActions,
       registerIncontextInsight: this.incontextInsightRegistry.register.bind(
         this.incontextInsightRegistry

--- a/public/types.ts
+++ b/public/types.ts
@@ -46,6 +46,10 @@ export interface AssistantSetup {
    * Returns true if chat UI is enabled.
    */
   chatEnabled: () => boolean;
+  /**
+   * Returns true if contextual assistant is enabled.
+   */
+  nextEnabled: () => boolean;
   assistantActions: Omit<AssistantActions, 'executeAction'>;
   registerIncontextInsight: IncontextInsightRegistry['register'];
   renderIncontextInsight: (component: React.ReactNode) => React.ReactNode;

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ export const config: PluginConfigDescriptor<ConfigSchema> = {
   exposeToBrowser: {
     chat: true,
     incontextInsight: true,
+    next: true,
   },
   schema: configSchema,
 };


### PR DESCRIPTION
### Description
Add a common feature flag to control query assistant like features like alert summary, anomaly detection creation and text2visualization.

Currently, naming candidates are as follows. New votings are welcome.

* assistant.next.enabled
* assistant.contextualAssistant.enabled
* assistant.experimental.enabled

### Issues Resolved


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
