### PR TITLE
feat: fix unit test ci failure

### DIFF
--- a/public/components/core_visualization.test.tsx
+++ b/public/components/core_visualization.test.tsx
@@ -9,6 +9,10 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import * as coreContextExports from '../contexts/core_context';
 import { CoreVisualization } from './core_visualization';
 
+jest.mock('../../../../src/plugins/embeddable/public', () => ({
+  ViewMode: jest.requireActual('../../../../src/plugins/embeddable/public/lib').ViewMode,
+}));
+
 describe('<CoreVisualization />', () => {
   beforeEach(() => {
     jest.spyOn(coreContextExports, 'useCore').mockReturnValue({


### PR DESCRIPTION
### Description

```
SyntaxError: Cannot use import statement outside a module

      31 | /* eslint-disable @osd/eslint/module_migration */
      32 |
    > 33 | import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
         | ^
      34 |
      35 | import 'monaco-editor/esm/vs/base/common/worker/simpleWorker';
      36 | import 'monaco-editor/esm/vs/base/worker/defaultWorkerFactory';

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1728:14)
      at Object.<anonymous> (../../packages/osd-monaco/src/monaco.ts:33:1)
      at Object.<anonymous> (../../packages/osd-monaco/src/index.ts:31:1)
      at Object.<anonymous> (../../src/plugins/data/public/antlr/opensearch_sql/code_completion.ts:6:1)
      at Object.<anonymous> (../../src/plugins/data/public/plugin.ts:96:1)
      at Object.<anonymous> (../../src/plugins/data/public/index.ts:503:1)
      at Object.<anonymous> (../../src/plugins/saved_objects/public/saved_object/helpers/serialize_saved_object.ts:34:1)
      at Object.<anonymous> (../../src/plugins/saved_objects/public/saved_object/helpers/build_saved_object.ts:34:1)
      at Object.<anonymous> (../../src/plugins/saved_objects/public/saved_object/saved_object.ts:42:1)
      at Object.<anonymous> (../../src/plugins/saved_objects/public/saved_object/index.ts:31:1)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        3.359 s
```

Embeddable plugin are introducing monaco editor and that breaks the CI of assistant. This PR is trying to fix that by only importing the viewMode from core by doing an intercept.

Making jest transform the `node_modules/monaco-editor` should work as well.

But the approach in this PR won't compile unnecessary modules when doing unit test.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
