### PR TITLE
fix: make sure $schema field always added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+### Unreleased
+- fix: make sure $schema always added to LLM generated vega json object([252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
+
 ### 📈 Features/Enhancements
 
 - Add support for registerMessageParser ([#5](https://github.com/opensearch-project/dashboards-assistant/pull/5))

--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -59,6 +59,9 @@ export function registerText2VizRoutes(router: IRouter) {
         delete result.width;
         delete result.height;
 
+        // make sure $schema field always been added, sometimes, LLM 'forgot' to add this field
+        result.$schema = 'https://vega.github.io/schema/vega-lite/v5.json';
+
         return res.ok({ body: result });
       } catch (e) {
         return res.internalError();


### PR DESCRIPTION
### Description
make sure $schema field always added to llm generated vega json config

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
