### PR TITLE
fix: make input_instruction can be empty string

### DIFF
--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -27,7 +27,7 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
       validate: {
         body: schema.object({
           input_question: inputSchema,
-          input_instruction: schema.maybe(inputSchema),
+          input_instruction: schema.maybe(schema.string({ maxLength: TEXT2VEGA_INPUT_SIZE_LIMIT })),
           ppl: schema.string(),
           dataSchema: schema.string(),
           sampleData: schema.string(),


### PR DESCRIPTION
### Description
Allow `input_instruction` to be empty string.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
