### PR TITLE
disable index patterns which data source has no agent configured for text to visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: add a dashboards-assistant trigger in query editor([265](https://github.com/opensearch-project/dashboards-assistant/pull/265))
 - fix: make sure $schema always added to LLM generated vega json object([#252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
 - feat: added a new visualization type visualization-nlq to support creating visualization from natural language([#264](https://github.com/opensearch-project/dashboards-assistant/pull/264))
+- feat: only allow to select supported index patterns in text to visualization and code changes related to prompt updates([#310](https://github.com/opensearch-project/dashboards-assistant/pull/310))
 - feat: exposed an API to check if a give agent config name has configured with agent id([#307](https://github.com/opensearch-project/dashboards-assistant/pull/307))
 
 ### 📈 Features/Enhancements

--- a/common/constants/llm.ts
+++ b/common/constants/llm.ts
@@ -44,5 +44,5 @@ export const DEFAULT_USER_NAME = 'User';
 
 export const TEXT2VEGA_INPUT_SIZE_LIMIT = 400;
 
-export const TEXT2VEGA_AGENT_CONFIG_ID = 'os_text2vega_new2';
+export const TEXT2VEGA_AGENT_CONFIG_ID = 'os_text2vega';
 export const TEXT2PPL_AGENT_CONFIG_ID = 'os_query_assist_ppl';

--- a/common/constants/llm.ts
+++ b/common/constants/llm.ts
@@ -43,3 +43,6 @@ export const NOTEBOOK_API = {
 export const DEFAULT_USER_NAME = 'User';
 
 export const TEXT2VEGA_INPUT_SIZE_LIMIT = 400;
+
+export const TEXT2VEGA_AGENT_CONFIG_ID = 'os_text2vega_new2';
+export const TEXT2PPL_AGENT_CONFIG_ID = 'os_query_assist_ppl';

--- a/public/components/visualization/source_selector.tsx
+++ b/public/components/visualization/source_selector.tsx
@@ -17,6 +17,8 @@ import { StartServices } from '../../types';
 import { TEXT2VEGA_AGENT_CONFIG_ID } from '../../../common/constants/llm';
 import { getAssistantService } from '../../services';
 
+const DEFAULT_DATA_SOURCE_TYPE = 'DEFAULT_INDEX_PATTERNS';
+
 export const SourceSelector = ({
   selectedSourceId,
   onChange,
@@ -75,18 +77,21 @@ export const SourceSelector = ({
 
   const onSetDataSourceOptions = useCallback(
     async (options: DataSourceGroup[]) => {
-      // Only support index pattern type of data set
+      // Only support opensearch default data source
       const indexPatternOptions = options.find(
-        (item) => item.groupType === 'DEFAULT_INDEX_PATTERNS'
+        (item) => item.groupType === DEFAULT_DATA_SOURCE_TYPE
+      );
+      const supportedDataSources = currentDataSources.filter(
+        (dataSource) => dataSource.getType() === DEFAULT_DATA_SOURCE_TYPE
       );
 
-      if (!indexPatternOptions) {
+      if (!indexPatternOptions || supportedDataSources.length === 0) {
         return;
       }
 
       // Group index pattern ids by data source id
       const dataSourceIdToIndexPatternIds: Record<string, string[]> = {};
-      const promises = currentDataSources.map(async (dataSource) => {
+      const promises = supportedDataSources.map(async (dataSource) => {
         const { dataSets } = await dataSource.getDataSet();
         if (Array.isArray(dataSets)) {
           /**

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -330,7 +330,7 @@ export const Text2Viz = () => {
   const getInputSection = () => {
     return (
       <>
-        <EuiFlexItem grow={3}>
+        <EuiFlexItem grow={3} style={{ maxWidth: '30%' }}>
           <SourceSelector
             selectedSourceId={selectedSource}
             onChange={(ds) => setSelectedSource(ds.value)}

--- a/server/routes/agent_routes.ts
+++ b/server/routes/agent_routes.ts
@@ -50,7 +50,7 @@ export function registerAgentRoutes(router: IRouter, assistantService: Assistant
       validate: {
         query: schema.oneOf([
           schema.object({
-            dataSourceId: schema.string(),
+            dataSourceId: schema.maybe(schema.string()),
             agentConfigName: schema.string(),
           }),
         ]),


### PR DESCRIPTION
1. disable index patterns which data source has no agent configured for text to visualization
2. extract vega json object from the response which is supposed to be in between tag <vega-lite></vega-lite>

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
