### PR TITLE
Make dataSourceId parameter optional for agent config_exist API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix: make sure $schema always added to LLM generated vega json object([#252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
 - feat: added a new visualization type visualization-nlq to support creating visualization from natural language([#264](https://github.com/opensearch-project/dashboards-assistant/pull/264))
 - feat: exposed an API to check if a give agent config name has configured with agent id([#307](https://github.com/opensearch-project/dashboards-assistant/pull/307))
+- fix: make dataSourceId parameter optional for agent config_exist API ([#311](https://github.com/opensearch-project/dashboards-assistant/pull/311))
 
 ### 📈 Features/Enhancements
 

--- a/server/routes/agent_routes.ts
+++ b/server/routes/agent_routes.ts
@@ -50,7 +50,7 @@ export function registerAgentRoutes(router: IRouter, assistantService: Assistant
       validate: {
         query: schema.oneOf([
           schema.object({
-            dataSourceId: schema.string(),
+            dataSourceId: schema.maybe(schema.string()),
             agentConfigName: schema.string(),
           }),
         ]),


### PR DESCRIPTION
### Description

The dataSourceId parameter in the agent config_exist API should be optional, for case dataSourceId is null for local cluster.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
