### PR TITLE
[Manual Backport 2.x] backport/backport-313-to-2.x

### DIFF
--- a/common/constants/llm.ts
+++ b/common/constants/llm.ts
@@ -44,5 +44,6 @@ export const DEFAULT_USER_NAME = 'User';
 
 export const TEXT2VEGA_INPUT_SIZE_LIMIT = 400;
 
-export const TEXT2VEGA_AGENT_CONFIG_ID = 'os_text2vega';
+export const TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID = 'os_text2vega';
+export const TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID = 'os_text2vega_with_instructions';
 export const TEXT2PPL_AGENT_CONFIG_ID = 'os_query_assist_ppl';

--- a/public/components/visualization/source_selector.tsx
+++ b/public/components/visualization/source_selector.tsx
@@ -14,7 +14,11 @@ import {
   DataSourceOption,
 } from '../../../../../src/plugins/data/public';
 import { StartServices } from '../../types';
-import { TEXT2VEGA_AGENT_CONFIG_ID } from '../../../common/constants/llm';
+import {
+  TEXT2PPL_AGENT_CONFIG_ID,
+  TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID,
+  TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID,
+} from '../../../common/constants/llm';
 import { getAssistantService } from '../../services';
 
 const DEFAULT_DATA_SOURCE_TYPE = 'DEFAULT_INDEX_PATTERNS';
@@ -110,13 +114,20 @@ export const SourceSelector = ({
 
       const assistantService = getAssistantService();
       /**
-       * Check each data source to see if text to vega agent is configured or not
+       * Check each data source to see if text to vega agents are configured or not
        * If not configured, disable the corresponding index pattern from the selection list
        */
       Object.keys(dataSourceIdToIndexPatternIds).forEach(async (key) => {
-        const res = await assistantService.client.agentConfigExists(TEXT2VEGA_AGENT_CONFIG_ID, {
-          dataSourceId: key !== 'DEFAULT' ? key : undefined,
-        });
+        const res = await assistantService.client.agentConfigExists(
+          [
+            TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID,
+            TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID,
+            TEXT2PPL_AGENT_CONFIG_ID,
+          ],
+          {
+            dataSourceId: key !== 'DEFAULT' ? key : undefined,
+          }
+        );
         if (!res.exists) {
           dataSourceIdToIndexPatternIds[key].forEach((indexPatternId) => {
             indexPatternOptions.options.forEach((option) => {

--- a/public/services/assistant_client.ts
+++ b/public/services/assistant_client.ts
@@ -38,9 +38,10 @@ export class AssistantClient {
   };
 
   /**
-   * Return if the given agent config name has agent id configured
+   * Check if the given agent config name has agent id configured
+   * Return false if any of the given config name has no agent id configured
    */
-  agentConfigExists = (agentConfigName: string, options?: Options) => {
+  agentConfigExists = (agentConfigName: string | string[], options?: Options) => {
     return this.http.fetch<{ exists: boolean }>({
       method: 'GET',
       path: AGENT_API.CONFIG_EXISTS,

--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -7,8 +7,9 @@ import { schema } from '@osd/config-schema';
 import { IRouter } from '../../../../src/core/server';
 import {
   TEXT2PPL_AGENT_CONFIG_ID,
-  TEXT2VEGA_AGENT_CONFIG_ID,
+  TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID,
   TEXT2VEGA_INPUT_SIZE_LIMIT,
+  TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID,
   TEXT2VIZ_API,
 } from '../../common/constants/llm';
 import { AssistantServiceSetup } from '../services/assistant_service';
@@ -42,7 +43,10 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
     router.handleLegacyErrors(async (context, req, res) => {
       const assistantClient = assistantService.getScopedClient(req, context);
       try {
-        const response = await assistantClient.executeAgentByConfigName(TEXT2VEGA_AGENT_CONFIG_ID, {
+        const agentConfigName = req.body.input_instruction
+          ? TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID
+          : TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID;
+        const response = await assistantClient.executeAgentByConfigName(agentConfigName, {
           input_question: req.body.input_question,
           input_instruction: req.body.input_instruction,
           ppl: req.body.ppl,


### PR DESCRIPTION
Manual backport #313 to 2.x

(cherry picked from commit 4a3fc51ae2ec64a86be3b03b6b9868e408988b88)

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
