### PR TITLE
fix(t2viz): string escape should only escape `field`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: check all required agents before enabling index pattern selection for text to visualization([313](https://github.com/opensearch-project/dashboards-assistant/pull/313))
 - fix: pass data source id for alert summary/insight([#321](https://github.com/opensearch-project/dashboards-assistant/pull/321))
 - feat: support navigating to discover in alerting popover([#316](https://github.com/opensearch-project/dashboards-assistant/pull/316))
+- fix: incorrect string escaping of vega schema([325](https://github.com/opensearch-project/dashboards-assistant/pull/325))
 
 ### 📈 Features/Enhancements
 

--- a/public/components/visualization/text2vega.ts
+++ b/public/components/visualization/text2vega.ts
@@ -108,7 +108,8 @@ export class Text2Vega {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const escapeField = (json: any, field: string) => {
       if (json[field]) {
-        if (typeof json[field] === 'string') {
+        // Only escape field which name is 'field'
+        if (typeof json[field] === 'string' && field === 'field') {
           json[field] = json[field].replace(/\./g, '\\.');
         }
         if (typeof json[field] === 'object') {
@@ -132,6 +133,7 @@ export class Text2Vega {
 
     // need to escape field: geo.city -> field: geo\\.city
     escapeField(res, 'encoding');
+    escapeField(res, 'layer');
     return res;
   }
 


### PR DESCRIPTION
### Description
1. Only escape field which name is `field`
2. Escape `field` when vega have different layers

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
