### PR TITLE
fix: fix create index pattern duplicate cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased
-- fix: make sure $schema always added to LLM generated vega json object([252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
+
+- fix: make sure \$schema always added to LLM generated vega json object([252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
 - feat: expose a general function for agent execution([268](https://github.com/opensearch-project/dashboards-assistant/pull/268))
 - Fix CVE-2024-4067 ([#269](https://github.com/opensearch-project/dashboards-assistant/pull/269))
 - feat: add a dashboards-assistant trigger in query editor([265](https://github.com/opensearch-project/dashboards-assistant/pull/265))
-- fix: make sure $schema always added to LLM generated vega json object([#252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
+- fix: make sure \$schema always added to LLM generated vega json object([#252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
 - feat: added a new visualization type visualization-nlq to support creating visualization from natural language([#264](https://github.com/opensearch-project/dashboards-assistant/pull/264))
 - feat: only allow to select supported index patterns in text to visualization and code changes related to prompt updates([#310](https://github.com/opensearch-project/dashboards-assistant/pull/310))
 - feat: exposed an API to check if a give agent config name has configured with agent id([#307](https://github.com/opensearch-project/dashboards-assistant/pull/307))
@@ -19,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix: t2viz ux improvements([#330](https://github.com/opensearch-project/dashboards-assistant/pull/330))
 - feat: report metrics for text to visualization([#312](https://github.com/opensearch-project/dashboards-assistant/pull/312))
 - fix: Fix dynamic uses of i18n([#335](https://github.com/opensearch-project/dashboards-assistant/pull/335))
+- fix: Fix unrecognized creating index pattern duplicate cases([#337](https://github.com/opensearch-project/dashboards-assistant/pull/337))
 
 ### 📈 Features/Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Unreleased
-
-- fix: make sure \$schema always added to LLM generated vega json object([252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
+- fix: make sure $schema always added to LLM generated vega json object([252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
 - feat: expose a general function for agent execution([268](https://github.com/opensearch-project/dashboards-assistant/pull/268))
 - Fix CVE-2024-4067 ([#269](https://github.com/opensearch-project/dashboards-assistant/pull/269))
 - feat: add a dashboards-assistant trigger in query editor([265](https://github.com/opensearch-project/dashboards-assistant/pull/265))
-- fix: make sure \$schema always added to LLM generated vega json object([#252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
+- fix: make sure $schema always added to LLM generated vega json object([#252](https://github.com/opensearch-project/dashboards-assistant/pull/252))
 - feat: added a new visualization type visualization-nlq to support creating visualization from natural language([#264](https://github.com/opensearch-project/dashboards-assistant/pull/264))
 - feat: only allow to select supported index patterns in text to visualization and code changes related to prompt updates([#310](https://github.com/opensearch-project/dashboards-assistant/pull/310))
 - feat: exposed an API to check if a give agent config name has configured with agent id([#307](https://github.com/opensearch-project/dashboards-assistant/pull/307))

--- a/public/utils/alerting.ts
+++ b/public/utils/alerting.ts
@@ -48,14 +48,15 @@ export const createIndexPatterns = async (
       dataSourceRef,
     });
   } catch (err) {
-    if (err instanceof DuplicateIndexPatternError) {
+    console.error('Create index pattern error', err.message);
+    // Err instanceof DuplicateIndexPatternError is not a trusted validation in some cases, so find index pattern directly.
+    try {
       const result = await dataStart.indexPatterns.find(patternName);
       if (result && result[0]) {
         pattern = result[0];
       }
-      console.error('Duplicate index pattern', err.message);
-    } else {
-      console.error('err', err.message);
+    } catch (e) {
+      console.error('Find index pattern error', err.message);
     }
   }
   return pattern;

--- a/public/utils/alerting.ts
+++ b/public/utils/alerting.ts
@@ -10,7 +10,6 @@ import { url } from '../../../../src/plugins/opensearch_dashboards_utils/public'
 import {
   DataPublicPluginStart,
   opensearchFilters,
-  DuplicateIndexPatternError,
   IndexPattern,
 } from '../../../../src/plugins/data/public';
 import { CoreStart } from '../../../../src/core/public';
@@ -91,7 +90,7 @@ export const buildUrlQuery = async (
       const dataSourceObject = await savedObjects.client.get('data-source', dataSourceId);
       const dataSourceTitle = dataSourceObject?.get('title');
       // If index pattern refers to a data source, discover list will display data source name as dataSourceTitle::indexPatternTitle
-      indexPatternTitle = `${dataSourceTitle}::indexPatternTitle`;
+      indexPatternTitle = `${dataSourceTitle}::${indexPatternTitle}`;
     } catch (e) {
       console.error('Get data source object error');
     }


### PR DESCRIPTION
### Description
The error of creating duplicate index pattern would not always be the instance of DuplicateIndexPatternError class in some cases, maybe in multi data source or in workspace scenarios, change to finding index pattern directly as a workaround.

NOTE: This is a workaround for now, will find and use another way to fully address after determining the detailed reason. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
