### PR TITLE
BugFix: [AlertInsight] Remove the cache of insight agent id in node server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: report metrics for text to visualization([#312](https://github.com/opensearch-project/dashboards-assistant/pull/312))
 - fix: Fix dynamic uses of i18n([#335](https://github.com/opensearch-project/dashboards-assistant/pull/335))
 - fix: Fix unrecognized creating index pattern duplicate cases([#337](https://github.com/opensearch-project/dashboards-assistant/pull/337))
+- fix: Remove the cache of insight agent id in node server([#343](https://github.com/opensearch-project/dashboards-assistant/pull/343))
 
 ### 📈 Features/Enhancements
 

--- a/public/components/incontext_insight/generate_popover_body.test.tsx
+++ b/public/components/incontext_insight/generate_popover_body.test.tsx
@@ -87,7 +87,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentIdExists: true,
+            insightAgentId: 'insightAgentId',
           };
           break;
 
@@ -168,7 +168,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentIdExists: false,
+            insightAgentId: undefined,
           };
           break;
 
@@ -245,7 +245,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentIdExists: true,
+            insightAgentId: 'insightAgentId',
           };
           break;
 
@@ -293,7 +293,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentIdExists: true,
+            insightAgentId: 'insightAgentId',
           };
           break;
 
@@ -335,7 +335,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentIdExists: true,
+            insightAgentId: 'insightAgentId',
           };
           break;
 

--- a/public/components/incontext_insight/generate_popover_body.test.tsx
+++ b/public/components/incontext_insight/generate_popover_body.test.tsx
@@ -87,7 +87,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentId: 'insightAgentId',
+            insightAgentIdExists: true,
           };
           break;
 
@@ -168,7 +168,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentId: undefined,
+            insightAgentIdExists: false,
           };
           break;
 
@@ -245,7 +245,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentId: 'insightAgentId',
+            insightAgentIdExists: true,
           };
           break;
 
@@ -293,7 +293,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentId: 'insightAgentId',
+            insightAgentIdExists: true,
           };
           break;
 
@@ -335,7 +335,7 @@ describe('GeneratePopoverBody', () => {
         case SUMMARY_ASSISTANT_API.SUMMARIZE:
           value = {
             summary: 'Generated summary content',
-            insightAgentId: 'insightAgentId',
+            insightAgentIdExists: true,
           };
           break;
 

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -122,7 +122,6 @@ export const GeneratePopoverBody: React.FC<{
         .then((response) => {
           const summaryContent = response.summary;
           setSummary(summaryContent);
-          const insightAgentId = response.insightAgentId;
           const insightAgentIdExists = !!insightType && response.insightAgentIdExists;
           setInsightAvailable(insightAgentIdExists);
           if (insightAgentIdExists) {

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -122,10 +122,12 @@ export const GeneratePopoverBody: React.FC<{
         .then((response) => {
           const summaryContent = response.summary;
           setSummary(summaryContent);
-          const insightAgentIdExists = insightType !== undefined && response.insightAgentIdExists;
+          const insightAgentId = response.insightAgentId;
+          const insightAgentIdExists = !!insightType && !!insightAgentId;
           setInsightAvailable(insightAgentIdExists);
           if (insightAgentIdExists) {
             onGenerateInsightBasedOnSummary(
+              insightAgentId,
               dataSourceQuery,
               summaryType,
               insightType,
@@ -150,6 +152,7 @@ export const GeneratePopoverBody: React.FC<{
   };
 
   const onGenerateInsightBasedOnSummary = (
+    insightAgentId: string,
     dataSourceQuery: {},
     summaryType: string,
     insightType: string,
@@ -161,6 +164,7 @@ export const GeneratePopoverBody: React.FC<{
       httpSetup
         ?.post(SUMMARY_ASSISTANT_API.INSIGHT, {
           body: JSON.stringify({
+            insightAgentId,
             summaryType,
             insightType,
             summary: summaryContent,

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -109,7 +109,7 @@ export const GeneratePopoverBody: React.FC<{
       await httpSetup
         ?.post(SUMMARY_ASSISTANT_API.SUMMARIZE, {
           body: JSON.stringify({
-            type: summaryType,
+            summaryType,
             insightType,
             question: summarizationQuestion,
             context: contextContent,
@@ -123,11 +123,10 @@ export const GeneratePopoverBody: React.FC<{
           const summaryContent = response.summary;
           setSummary(summaryContent);
           const insightAgentId = response.insightAgentId;
-          const insightAgentIdExists = !!insightType && !!insightAgentId;
+          const insightAgentIdExists = !!insightType && response.insightAgentIdExists;
           setInsightAvailable(insightAgentIdExists);
           if (insightAgentIdExists) {
             onGenerateInsightBasedOnSummary(
-              insightAgentId,
               dataSourceQuery,
               summaryType,
               insightType,
@@ -152,7 +151,6 @@ export const GeneratePopoverBody: React.FC<{
   };
 
   const onGenerateInsightBasedOnSummary = (
-    insightAgentId: string,
     dataSourceQuery: {},
     summaryType: string,
     insightType: string,
@@ -164,7 +162,6 @@ export const GeneratePopoverBody: React.FC<{
       httpSetup
         ?.post(SUMMARY_ASSISTANT_API.INSIGHT, {
           body: JSON.stringify({
-            insightAgentId,
             summaryType,
             insightType,
             summary: summaryContent,

--- a/server/routes/summary_routes.ts
+++ b/server/routes/summary_routes.ts
@@ -11,7 +11,7 @@ import { getAgentIdByConfigName, searchAgent } from './get_agent';
 import { AssistantServiceSetup } from '../services/assistant_service';
 
 const SUMMARY_AGENT_CONFIG_ID = 'os_summary';
-const LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID = 'os_summary_with_logPattern';
+const LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID = 'os_summary_with_log_pattern';
 const OS_INSIGHT_AGENT_CONFIG_ID = 'os_insight';
 const DATA2SUMMARY_AGENT_CONFIG_ID = 'os_data2summary';
 
@@ -67,7 +67,7 @@ export function registerSummaryAssistantRoutes(
           }
         }
       } catch (e) {
-        context.assistant_plugin.logger.info(
+        context.assistant_plugin.logger.debug(
           `Cannot find insight agent for ${req.body.insightType}`,
           e
         );

--- a/server/routes/summary_routes.ts
+++ b/server/routes/summary_routes.ts
@@ -74,7 +74,7 @@ export function registerSummaryAssistantRoutes(
         summary = response.body.inference_results[0].output[0].result;
         return res.ok({ body: { summary, insightAgentIdExists } });
       } catch (e) {
-        return res.internalError();
+        return res.badRequest({ body: e });
       }
     })
   );
@@ -113,7 +113,7 @@ export function registerSummaryAssistantRoutes(
       try {
         return res.ok({ body: response.body.inference_results[0].output[0].result });
       } catch (e) {
-        return res.internalError();
+        return res.badRequest({ body: e });
       }
     })
   );
@@ -131,6 +131,7 @@ function detectInsightAgentId(
   } else if (insightType === 'user_insight' && summaryType === 'alerts') {
     return searchAgent({ name: 'KB_For_Alert_Insight' }, client);
   }
+  return undefined;
 }
 
 export function registerData2SummaryRoutes(
@@ -169,7 +170,7 @@ export function registerData2SummaryRoutes(
         const result = response.body.inference_results[0].output[0].result;
         return res.ok({ body: result });
       } catch (e) {
-        return res.internalError();
+        return res.badRequest({ body: e });
       }
     })
   );

--- a/server/routes/summary_routes.ts
+++ b/server/routes/summary_routes.ts
@@ -121,14 +121,14 @@ export function registerSummaryAssistantRoutes(
 
 function detectInsightAgentId(
   insightType: string,
-  appType: string,
+  summaryType: string,
   client: OpenSearchClient['transport']
 ) {
   // We have separate agent for os_insight and user_insight. And for user_insight, we can
   // only get it by searching on name since it is not stored in agent config.
   if (insightType === 'os_insight') {
     return getAgentIdByConfigName(OS_INSIGHT_AGENT_CONFIG_ID, client);
-  } else if (insightType === 'user_insight' && appType === 'alerts') {
+  } else if (insightType === 'user_insight' && summaryType === 'alerts') {
     return searchAgent({ name: 'KB_For_Alert_Insight' }, client);
   }
 }


### PR DESCRIPTION
### Description
Remove the cache of insight agent id in node server.  

~~Pass insight agent id to front-end to indicate that the agent exists, and then the front-end can use the agent id in its next request directly to retrieve insight.~~ 

Detect insight agent id twice to remove the cache:
1. First in summary request to detect whether insight agent exists
2. Second in insight request to get the insight agent id for execution agent.

There will be an potential issue that different requests could be sent to different nodes server and cause error if depending on the cache of insight agent id.


### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
