### PR TITLE
Add data source info in discover url when navigating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix: Fix unrecognized creating index pattern duplicate cases([#337](https://github.com/opensearch-project/dashboards-assistant/pull/337))
 - fix: Remove the cache of insight agent id in node server([#343](https://github.com/opensearch-project/dashboards-assistant/pull/343))
 - fix: Fix error time field and add filter for same name index patterns([#345](https://github.com/opensearch-project/dashboards-assistant/pull/345))
+- refactor: Add data source info in discover url when navigating([#347](https://github.com/opensearch-project/dashboards-assistant/pull/347))
 
 
 ### 📈 Features/Enhancements

--- a/public/utils/alerting.ts
+++ b/public/utils/alerting.ts
@@ -88,13 +88,17 @@ export const buildUrlQuery = async (
     from: timeDsl.from,
     to: timeDsl.to,
   };
-  let indexPatternTitle = indexPattern.title;
+  const indexPatternTitle = indexPattern.title;
+  let dataSource;
   if (dataSourceId) {
     try {
       const dataSourceObject = await savedObjects.client.get('data-source', dataSourceId);
-      const dataSourceTitle = dataSourceObject?.get('title');
-      // If index pattern refers to a data source, discover list will display data source name as dataSourceTitle::indexPatternTitle
-      indexPatternTitle = `${dataSourceTitle}::${indexPatternTitle}`;
+      const dataSourceTitle = dataSourceObject?.get('title') ?? '';
+      dataSource = {
+        id: dataSourceId,
+        title: dataSourceTitle,
+        type: 'OpenSearch',
+      };
     } catch (e) {
       console.error('Get data source object error');
     }
@@ -107,6 +111,7 @@ export const buildUrlQuery = async (
         id: indexPattern.id,
         timeFieldName: indexPattern.timeFieldName,
         title: indexPatternTitle,
+        ...(dataSource ? { dataSource } : {}),
       },
       language: 'kuery',
       query: '',


### PR DESCRIPTION
### Description
Add data source info in discover url when navigating

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
