### PR TITLE
Minor UX change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: Hide incompatible index patterns ([#354] (https://github.com/opensearch-project/dashboards-assistant/pull/354))
 - feat: edit visualization with natural language in a dialog([#351](https://github.com/opensearch-project/dashboards-assistant/pull/351))
 - fix: Update alerting DSL verify mechanism([#359](https://github.com/opensearch-project/dashboards-assistant/pull/359))
+- fix: minor UX change([#364](https://github.com/opensearch-project/dashboards-assistant/pull/364))
 
 
 ### 📈 Features/Enhancements

--- a/public/assets/filled_sparkle.svg
+++ b/public/assets/filled_sparkle.svg
@@ -1,0 +1,15 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0_433_129748)">
+    <g clip-path="url(#clip1_433_129748)">
+      <g clip-path="url(#clip2_433_129748)">
+        <path d="M7.64258 3.45923L9.05679 7.04501L12.6426 8.45923L9.05679 9.87344L7.64258 13.4592L6.22836 9.87344L2.64258 8.45923L6.22836 7.04501L7.64258 3.45923Z" fill="#006BB4" stroke="#006BB4" stroke-linejoin="round"/>
+        <path d="M3.14258 1.95923L3.77897 3.32283L5.14258 3.95923L3.77897 4.59562L3.14258 5.95923L2.50618 4.59562L1.14258 3.95923L2.50618 3.32283L3.14258 1.95923Z" fill="#006BB4"/>
+      </g>
+    </g>
+  </g>
+  <defs>
+    <clipPath id="clip0_985_188100">
+      <rect width="22.8571" height="22.8571" fill="white" transform="translate(8.57129 8.57129)"/>
+    </clipPath>
+  </defs>
+</svg>

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -334,7 +334,7 @@ export const GeneratePopoverBody: React.FC<{
             <MessageActions
               contentToCopy={insight}
               showFeedback
-              showTraceIcon={insightAvailable}
+              showTraceIcon={false}
               onViewTrace={() => {}}
               usageCollection={usageCollection}
               isOnTrace={showInsight}

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -293,8 +293,8 @@ export const GeneratePopoverBody: React.FC<{
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiText>
-              <EuiTitle size="xxs">
-                <h6>
+              <EuiTitle size="xxxs">
+                <p>
                   {showInsight
                     ? i18n.translate('assistantDashboards.inContextInsight.withRAGSummary', {
                         defaultMessage: 'Insight With RAG',
@@ -302,7 +302,7 @@ export const GeneratePopoverBody: React.FC<{
                     : i18n.translate('assistantDashboards.inContextInsight.summary', {
                         defaultMessage: 'Summary',
                       })}
-                </h6>
+                </p>
               </EuiTitle>
             </EuiText>
           </EuiFlexItem>

--- a/public/components/incontext_insight/index.tsx
+++ b/public/components/incontext_insight/index.tsx
@@ -30,7 +30,7 @@ import { IncontextInsight as IncontextInsightInput } from '../../types';
 import { getIncontextInsightRegistry, getNotifications } from '../../services';
 // TODO: Replace with getChrome().logos.Chat.url
 import chatIcon from '../../assets/chat.svg';
-import sparkle from '../../assets/sparkle.svg';
+import filled_sparkle from '../../assets/filled_sparkle.svg';
 import { HttpSetup, StartServicesAccessor } from '../../../../../src/core/public';
 import { GeneratePopoverBody } from './generate_popover_body';
 import { UsageCollectionSetup } from '../../../../../src/plugins/usage_collection/public/plugin';
@@ -270,7 +270,7 @@ export const IncontextInsight = ({
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <div className="incontextInsightAnchorIcon">
-            <EuiIcon type={input.type === 'generate' ? sparkle : chatIcon} size="l" />
+            <EuiIcon type={input.type === 'generate' ? filled_sparkle : chatIcon} size="l" />
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>


### PR DESCRIPTION
### Description
1. Avoid using uppercase in alert summary/insight popover title
2. Change alert summary icon to filled_sparkle
3. Hide trace icon when showing alert insight

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
