### PR TITLE
feat: only support visual editor alerts to navigate to discover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: edit visualization with natural language in a dialog([#351](https://github.com/opensearch-project/dashboards-assistant/pull/351))
 - fix: Update alerting DSL verify mechanism([#359](https://github.com/opensearch-project/dashboards-assistant/pull/359))
 - fix: Refactor contextProvider get to reduce re-fetch([#365](https://github.com/opensearch-project/dashboards-assistant/pull/365))
+- feat: Hide navigate to discover button if alert is not from visual editor monitor([#368](https://github.com/opensearch-project/dashboards-assistant/pull/368))
 
 
 ### 📈 Features/Enhancements

--- a/public/components/incontext_insight/generate_popover_body.test.tsx
+++ b/public/components/incontext_insight/generate_popover_body.test.tsx
@@ -338,6 +338,7 @@ describe('GeneratePopoverBody', () => {
         index: 'mock_index',
         dataSourceId: `test-data-source-id`,
         monitorType: 'query_level_monitor',
+        isVisualEditorMonitor: true,
       },
     });
     mockPost.mockImplementation((path: string, body) => {
@@ -383,5 +384,57 @@ describe('GeneratePopoverBody', () => {
       fireEvent.click(button);
     });
     expect(window.open).toHaveBeenCalledWith('formattedUrl', '_blank');
+  });
+
+  it('should hide navigate to discover if not from visual editor monitor', async () => {
+    incontextInsightMock.contextProvider = jest.fn().mockResolvedValue({
+      additionalInfo: {
+        dsl: mockDSL,
+        index: 'mock_index',
+        dataSourceId: `test-data-source-id`,
+        monitorType: 'query_level_monitor',
+        isVisualEditorMonitor: false,
+      },
+    });
+    mockPost.mockImplementation((path: string, body) => {
+      let value;
+      switch (path) {
+        case SUMMARY_ASSISTANT_API.SUMMARIZE:
+          value = {
+            summary: 'Generated summary content',
+            insightAgentIdExists: true,
+          };
+          break;
+
+        case SUMMARY_ASSISTANT_API.INSIGHT:
+          value = 'Generated insight content';
+          break;
+
+        default:
+          return null;
+      }
+      return Promise.resolve(value);
+    });
+
+    const coreStart = coreMock.createStart();
+    const dataStart = dataPluginMock.createStartContract();
+    const getStartServices = jest.fn().mockResolvedValue([
+      coreStart,
+      {
+        data: dataStart,
+      },
+    ]);
+    const { queryByText } = render(
+      <GeneratePopoverBody
+        incontextInsight={incontextInsightMock}
+        httpSetup={mockHttpSetup}
+        closePopover={closePopoverMock}
+        getStartServices={getStartServices}
+      />
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Discover details')).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -58,6 +58,11 @@ export const GeneratePopoverBody: React.FC<{
       if (!contextObject) return;
       const monitorType = contextObject?.additionalInfo?.monitorType;
       const dsl = contextObject?.additionalInfo?.dsl;
+      const isVisualEditorMonitor = contextObject?.additionalInfo?.isVisualEditorMonitor;
+      // Only alerts from visual editor monitor support to navigate to discover.
+      if (!isVisualEditorMonitor) {
+        return;
+      }
       // Only this two types from alerting contain DSL and index.
       const isSupportedMonitorType =
         monitorType === 'query_level_monitor' || monitorType === 'bucket_level_monitor';


### PR DESCRIPTION
### Description
only support visual editor alerts to navigate to discover

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
