### PR TITLE
Revert "feat: only support visual editor alerts to navigate to discover"

### DIFF
--- a/public/components/incontext_insight/generate_popover_body.test.tsx
+++ b/public/components/incontext_insight/generate_popover_body.test.tsx
@@ -338,7 +338,6 @@ describe('GeneratePopoverBody', () => {
         index: 'mock_index',
         dataSourceId: `test-data-source-id`,
         monitorType: 'query_level_monitor',
-        isVisualEditorMonitor: true,
       },
     });
     mockPost.mockImplementation((path: string, body) => {
@@ -384,57 +383,5 @@ describe('GeneratePopoverBody', () => {
       fireEvent.click(button);
     });
     expect(window.open).toHaveBeenCalledWith('formattedUrl', '_blank');
-  });
-
-  it('should hide navigate to discover if not from visual editor monitor', async () => {
-    incontextInsightMock.contextProvider = jest.fn().mockResolvedValue({
-      additionalInfo: {
-        dsl: mockDSL,
-        index: 'mock_index',
-        dataSourceId: `test-data-source-id`,
-        monitorType: 'query_level_monitor',
-        isVisualEditorMonitor: false,
-      },
-    });
-    mockPost.mockImplementation((path: string, body) => {
-      let value;
-      switch (path) {
-        case SUMMARY_ASSISTANT_API.SUMMARIZE:
-          value = {
-            summary: 'Generated summary content',
-            insightAgentIdExists: true,
-          };
-          break;
-
-        case SUMMARY_ASSISTANT_API.INSIGHT:
-          value = 'Generated insight content';
-          break;
-
-        default:
-          return null;
-      }
-      return Promise.resolve(value);
-    });
-
-    const coreStart = coreMock.createStart();
-    const dataStart = dataPluginMock.createStartContract();
-    const getStartServices = jest.fn().mockResolvedValue([
-      coreStart,
-      {
-        data: dataStart,
-      },
-    ]);
-    const { queryByText } = render(
-      <GeneratePopoverBody
-        incontextInsight={incontextInsightMock}
-        httpSetup={mockHttpSetup}
-        closePopover={closePopoverMock}
-        getStartServices={getStartServices}
-      />
-    );
-
-    await waitFor(() => {
-      expect(queryByText('Discover details')).not.toBeInTheDocument();
-    });
   });
 });

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -58,11 +58,6 @@ export const GeneratePopoverBody: React.FC<{
       if (!contextObject) return;
       const monitorType = contextObject?.additionalInfo?.monitorType;
       const dsl = contextObject?.additionalInfo?.dsl;
-      const isVisualEditorMonitor = contextObject?.additionalInfo?.isVisualEditorMonitor;
-      // Only alerts from visual editor monitor support to navigate to discover.
-      if (!isVisualEditorMonitor) {
-        return;
-      }
       // Only this two types from alerting contain DSL and index.
       const isSupportedMonitorType =
         monitorType === 'query_level_monitor' || monitorType === 'bucket_level_monitor';


### PR DESCRIPTION

This PR reverts commit 2ba485368c2b37f667509b9a09f1c5430aa4463d(feat: only support visual editor alerts to navigate to discover).

### Description
Revert this PR as it's not included in 2.18, this PR is a very minor change and not depended by others so it will be released in 2.19.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
