### PR TITLE
Optimize the response of AI agent APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: Hide navigate to discover button if alert is not from visual editor monitor([#368](https://github.com/opensearch-project/dashboards-assistant/pull/368))
 
 ### Bug Fixes
+- Optimize the response of AI agent APIs ([#373](https://github.com/opensearch-project/dashboards-assistant/pull/373))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/server/routes/agent_routes.ts
+++ b/server/routes/agent_routes.ts
@@ -39,7 +39,7 @@ export function registerAgentRoutes(router: IRouter, assistantService: Assistant
         );
         return res.ok({ body: response });
       } catch (e) {
-        context.assistant_plugin.logger.debug('Execute agent failed!', e);
+        context.assistant_plugin.logger.error('Execute agent failed!', e);
         if (e.statusCode >= 400 && e.statusCode <= 499) {
           return res.customError({
             body: e.body,

--- a/server/routes/agent_routes.ts
+++ b/server/routes/agent_routes.ts
@@ -39,7 +39,20 @@ export function registerAgentRoutes(router: IRouter, assistantService: Assistant
         );
         return res.ok({ body: response });
       } catch (e) {
-        return res.badRequest();
+        context.assistant_plugin.logger.debug('Execute agent failed!', e);
+        if (e.statusCode >= 400 && e.statusCode <= 499) {
+          return res.customError({
+            body: e.body,
+            statusCode: e.statusCode,
+            headers: e.headers,
+          });
+        } else {
+          return res.customError({
+            body: 'Execute agent failed!',
+            statusCode: 500,
+            headers: e.headers,
+          });
+        }
       }
     })
   );

--- a/server/routes/summary_routes.ts
+++ b/server/routes/summary_routes.ts
@@ -58,11 +58,20 @@ export function registerSummaryAssistantRoutes(
           topNLogPatternData: req.body.topNLogPatternData,
         });
       } catch (e) {
-        return res.customError({
-          body: e.body || 'execute agent failed',
-          statusCode: e.statusCode || 500,
-          headers: e.headers,
-        });
+        context.assistant_plugin.logger.error('Execute agent failed!', e);
+        if (e.statusCode >= 400 && e.statusCode <= 499) {
+          return res.customError({
+            body: e.body,
+            statusCode: e.statusCode,
+            headers: e.headers,
+          });
+        } else {
+          return res.customError({
+            body: 'Execute agent failed!',
+            statusCode: 500,
+            headers: e.headers,
+          });
+        }
       }
 
       let summary;
@@ -126,11 +135,20 @@ export function registerSummaryAssistantRoutes(
           question: req.body.question,
         });
       } catch (e) {
-        return res.customError({
-          body: e.body || 'execute agent failed',
-          statusCode: e.statusCode || 500,
-          headers: e.headers,
-        });
+        context.assistant_plugin.logger.error('Execute agent failed!', e);
+        if (e.statusCode >= 400 && e.statusCode <= 499) {
+          return res.customError({
+            body: e.body,
+            statusCode: e.statusCode,
+            headers: e.headers,
+          });
+        } else {
+          return res.customError({
+            body: 'Execute agent failed!',
+            statusCode: 500,
+            headers: e.headers,
+          });
+        }
       }
 
       try {
@@ -191,11 +209,20 @@ export function registerData2SummaryRoutes(
         const result = response.body.inference_results[0].output[0].result;
         return res.ok({ body: result });
       } catch (e) {
-        return res.customError({
-          body: e.body || 'execute agent failed',
-          statusCode: e.statusCode || 500,
-          headers: e.headers,
-        });
+        context.assistant_plugin.logger.error('Execute agent failed!', e);
+        if (e.statusCode >= 400 && e.statusCode <= 499) {
+          return res.customError({
+            body: e.body,
+            statusCode: e.statusCode,
+            headers: e.headers,
+          });
+        } else {
+          return res.customError({
+            body: 'Execute agent failed!',
+            statusCode: 500,
+            headers: e.headers,
+          });
+        }
       }
     })
   );

--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -86,11 +86,20 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         }
         return res.badRequest();
       } catch (e) {
-        return res.customError({
-          body: e.body || 'execute agent failed',
-          statusCode: e.statusCode || 500,
-          headers: e.headers,
-        });
+        context.assistant_plugin.logger.error('Execute agent failed!', e);
+        if (e.statusCode >= 400 && e.statusCode <= 499) {
+          return res.customError({
+            body: e.body,
+            statusCode: e.statusCode,
+            headers: e.headers,
+          });
+        } else {
+          return res.customError({
+            body: 'Execute agent failed!',
+            statusCode: 500,
+            headers: e.headers,
+          });
+        }
       }
     })
   );

--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -119,11 +119,20 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         const result = JSON.parse(response.body.inference_results[0].output[0].result);
         return res.ok({ body: result });
       } catch (e) {
-        return res.customError({
-          body: e.body || 'execute agent failed',
-          statusCode: e.statusCode || 500,
-          headers: e.headers,
-        });
+        context.assistant_plugin.logger.error('Execute agent failed!', e);
+        if (e.statusCode >= 400 && e.statusCode <= 499) {
+          return res.customError({
+            body: e.body,
+            statusCode: e.statusCode,
+            headers: e.headers,
+          });
+        } else {
+          return res.customError({
+            body: 'Execute agent failed!',
+            statusCode: 500,
+            headers: e.headers,
+          });
+        }
       }
     })
   );

--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -86,7 +86,11 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         }
         return res.badRequest();
       } catch (e) {
-        return res.badRequest();
+        return res.customError({
+          body: e.body || 'execute agent failed',
+          statusCode: e.statusCode || 500,
+          headers: e.headers,
+        });
       }
     })
   );
@@ -115,7 +119,11 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         const result = JSON.parse(response.body.inference_results[0].output[0].result);
         return res.ok({ body: result });
       } catch (e) {
-        return res.badRequest();
+        return res.customError({
+          body: e.body || 'execute agent failed',
+          statusCode: e.statusCode || 500,
+          headers: e.headers,
+        });
       }
     })
   );


### PR DESCRIPTION
### Description

When calling the APIs like api/assistant/summary, api/assistant/insight and other related APIs, if OpenSearch cluster returns 4xx error, we just return 500 error or 400 error directly, which is not elegant, we should optimize this by checking the status code, if it's 4xx error, we return the original response, and if it's 5xx error, return an general error message.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
