### PR TITLE
fixed incorrect message id field used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,22 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
+
 ### Features
+
 ### Enhancements
+
 - feat: Hide navigate to discover button if alert is not from visual editor monitor([#368](https://github.com/opensearch-project/dashboards-assistant/pull/368))
 
 ### Bug Fixes
+
 - Optimize the response of AI agent APIs ([#373](https://github.com/opensearch-project/dashboards-assistant/pull/373))
+- fixed incorrect message id field used ([#378](https://github.com/opensearch-project/dashboards-assistant/pull/378))
 
 ### Infrastructure
+
 ### Documentation
+
 ### Maintenance
+
 ### Refactoring

--- a/server/services/chat/olly_chat_service.ts
+++ b/server/services/chat/olly_chat_service.ts
@@ -19,7 +19,7 @@ interface AgentRunPayload {
 }
 
 const MEMORY_ID_FIELD = 'memory_id';
-const INTERACTION_ID_FIELD = 'parent_interaction_id';
+const INTERACTION_ID_FIELDS = ['parent_message_id', 'parent_interaction_id'];
 
 export class OllyChatService implements ChatService {
   static abortControllers: Map<string, AbortController> = new Map();
@@ -67,7 +67,9 @@ export class OllyChatService implements ChatService {
       }>;
       const outputBody = agentFrameworkResponse.body.inference_results?.[0]?.output;
       const conversationIdItem = outputBody?.find((item) => item.name === MEMORY_ID_FIELD);
-      const interactionIdItem = outputBody?.find((item) => item.name === INTERACTION_ID_FIELD);
+      const interactionIdItem = outputBody?.find((item) =>
+        INTERACTION_ID_FIELDS.includes(item.name)
+      );
       return {
         /**
          * Interactions will be stored in Agent framework,


### PR DESCRIPTION
ml-commons changed the agent execution response { name: 'parent_interaction_id' } to { name: 'parent_message_id' } for conversational_flow type of agent.
This commit update the fields used at FE to make it work for both case.

### Description
[Describe what this change achieves]

### Issues Resolved
resolved #377 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
