### PR TITLE
[Chatbot] Add feature flags for traces and feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 ### Enhancements
 - feat: Hide navigate to discover button if alert is not from visual editor monitor([#368](https://github.com/opensearch-project/dashboards-assistant/pull/368))
+- Add a flag in the config to control the trace view button in message bubbles ([#379](https://github.com/opensearch-project/dashboards-assistant/pull/379))
 
 ### Bug Fixes
 - Optimize the response of AI agent APIs ([#373](https://github.com/opensearch-project/dashboards-assistant/pull/373))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 ### Enhancements
 - feat: Hide navigate to discover button if alert is not from visual editor monitor([#368](https://github.com/opensearch-project/dashboards-assistant/pull/368))
-- Add a flag in the config to control the trace view button in message bubbles ([#379](https://github.com/opensearch-project/dashboards-assistant/pull/379))
+- Add flags in the config to control trace view and feedback buttons in message bubbles ([#379](https://github.com/opensearch-project/dashboards-assistant/pull/379))
 
 ### Bug Fixes
 - Optimize the response of AI agent APIs ([#373](https://github.com/opensearch-project/dashboards-assistant/pull/373))

--- a/common/types/config.ts
+++ b/common/types/config.ts
@@ -9,6 +9,7 @@ export const configSchema = schema.object({
   enabled: schema.boolean({ defaultValue: true }),
   chat: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
+    trace: schema.boolean({ defaultValue: true }),
   }),
   incontextInsight: schema.object({
     enabled: schema.boolean({ defaultValue: true }),

--- a/common/types/config.ts
+++ b/common/types/config.ts
@@ -10,6 +10,7 @@ export const configSchema = schema.object({
   chat: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
     trace: schema.boolean({ defaultValue: true }),
+    feedback: schema.boolean({ defaultValue: true }),
   }),
   incontextInsight: schema.object({
     enabled: schema.boolean({ defaultValue: true }),

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -321,6 +321,7 @@ export const GeneratePopoverBody: React.FC<{
   };
 
   const renderInnerFooter = () => {
+    const traceTip = 'Insight With RAG';
     return (
       <EuiPopoverFooter className="incontextInsightGeneratePopoverFooter" paddingSize="none">
         {
@@ -332,6 +333,7 @@ export const GeneratePopoverBody: React.FC<{
               onViewTrace={() => {
                 setShowInsight(true);
               }}
+              traceTip={traceTip}
               usageCollection={usageCollection}
               isOnTrace={showInsight}
               metricAppName={metricAppName}
@@ -345,6 +347,7 @@ export const GeneratePopoverBody: React.FC<{
               showFeedback
               showTraceIcon={insightAvailable}
               onViewTrace={() => {}}
+              traceTip={traceTip}
               usageCollection={usageCollection}
               isOnTrace={showInsight}
               metricAppName={metricAppName}

--- a/public/tabs/chat/messages/message_action.tsx
+++ b/public/tabs/chat/messages/message_action.tsx
@@ -22,6 +22,7 @@ interface MessageActionsProps {
   showTraceIcon?: boolean;
   isOnTrace?: boolean;
   traceInteractionId?: string;
+  traceTip?: string;
   onViewTrace?: () => void;
   shouldActionBarVisibleOnHover?: boolean;
   isFullWidth?: boolean;
@@ -44,6 +45,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
   showTraceIcon = false,
   isOnTrace = false,
   traceInteractionId = null,
+  traceTip = 'info',
   onViewTrace,
   shouldActionBarVisibleOnHover = false,
   isFullWidth = false,
@@ -146,7 +148,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
     trace: {
       show: showTraceIcon && onViewTrace,
       component: renderButtonWithTooltip(
-        'Insight with RAG',
+        traceTip,
         <EuiSmallButtonIcon
           aria-label="How was this generated?"
           {...(traceInteractionId && {

--- a/public/tabs/chat/messages/message_bubble.test.tsx
+++ b/public/tabs/chat/messages/message_bubble.test.tsx
@@ -19,7 +19,9 @@ describe('<MessageBubble />', () => {
   const reportUiStatsMock = jest.fn();
 
   beforeEach(() => {
-    jest.spyOn(services, 'getConfigSchema').mockReturnValue({ chat: { trace: true } });
+    jest
+      .spyOn(services, 'getConfigSchema')
+      .mockReturnValue({ chat: { trace: true, feedback: true } });
     jest
       .spyOn(useFeedbackHookExports, 'useFeedback')
       .mockReturnValue({ feedbackResult: undefined, sendFeedback: sendFeedbackMock });
@@ -335,5 +337,34 @@ describe('<MessageBubble />', () => {
       />
     );
     expect(screen.queryByTestId('trace-icon-bar2')).toBeNull();
+  });
+
+  it('should control feedback buttons through config flag', () => {
+    const { rerender } = render(
+      <MessageBubble
+        showActionBar={true}
+        message={{
+          type: 'output',
+          contentType: 'markdown',
+          content: 'here are the indices in your cluster: .alert',
+        }}
+      />
+    );
+    expect(screen.queryByLabelText('feedback thumbs down')).toBeVisible();
+    expect(screen.queryByLabelText('feedback thumbs up')).toBeVisible();
+
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({ chat: { feedback: false } });
+    rerender(
+      <MessageBubble
+        showActionBar={true}
+        message={{
+          type: 'output',
+          contentType: 'markdown',
+          content: 'here are the indices in your cluster: .alert',
+        }}
+      />
+    );
+    expect(screen.queryByLabelText('feedback thumbs down')).toBeNull();
+    expect(screen.queryByLabelText('feedback thumbs up')).toBeNull();
   });
 });

--- a/public/tabs/chat/messages/message_bubble.test.tsx
+++ b/public/tabs/chat/messages/message_bubble.test.tsx
@@ -8,6 +8,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 
 import { MessageBubble } from './message_bubble';
 import { IOutput } from '../../../../common/types/chat_saved_object_attributes';
+import * as services from '../../../services';
 import * as useFeedbackHookExports from '../../../hooks/use_feed_back';
 import * as useChatActionsExports from '../../../hooks/use_chat_actions';
 import * as coreHookExports from '../../../contexts/core_context';
@@ -18,6 +19,7 @@ describe('<MessageBubble />', () => {
   const reportUiStatsMock = jest.fn();
 
   beforeEach(() => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({ chat: { trace: true } });
     jest
       .spyOn(useFeedbackHookExports, 'useFeedback')
       .mockReturnValue({ feedbackResult: undefined, sendFeedback: sendFeedbackMock });
@@ -288,5 +290,50 @@ describe('<MessageBubble />', () => {
       />
     );
     expect(screen.queryByTestId('trace-icon-bar')).toBeNull();
+  });
+
+  it('should control view trace through config flag', () => {
+    render(
+      <MessageBubble
+        showActionBar={true}
+        showRegenerate={true}
+        message={{
+          type: 'output',
+          contentType: 'markdown',
+          content: 'here are the indices in your cluster: .alert',
+          interactionId: 'bar1',
+        }}
+        interaction={{
+          input: 'foo',
+          response: 'bar1',
+          conversation_id: 'foo',
+          interaction_id: 'bar1',
+          create_time: new Date().toLocaleString(),
+        }}
+      />
+    );
+    expect(screen.queryByTestId('trace-icon-bar1')).toBeVisible();
+
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({ chat: { trace: false } });
+    render(
+      <MessageBubble
+        showActionBar={true}
+        showRegenerate={true}
+        message={{
+          type: 'output',
+          contentType: 'markdown',
+          content: 'here are the indices in your cluster: .alert',
+          interactionId: 'bar2',
+        }}
+        interaction={{
+          input: 'foo',
+          response: 'bar2',
+          conversation_id: 'foo',
+          interaction_id: 'bar2',
+          create_time: new Date().toLocaleString(),
+        }}
+      />
+    );
+    expect(screen.queryByTestId('trace-icon-bar2')).toBeNull();
   });
 });

--- a/public/tabs/chat/messages/message_bubble.tsx
+++ b/public/tabs/chat/messages/message_bubble.tsx
@@ -47,8 +47,11 @@ type MessageBubbleProps = {
 export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) => {
   const { executeAction } = useChatActions();
   const core = useCore();
+  const configSchema = getConfigSchema();
+
   // According to the design of the feedback, only markdown type output is supported.
   const showFeedback =
+    configSchema.chat.feedback &&
     'message' in props &&
     props.message.type === 'output' &&
     props.message.contentType === 'markdown';
@@ -124,7 +127,6 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
     }
 
     const fullWidth = props.message.fullWidth;
-    const configSchema = getConfigSchema();
 
     return (
       <EuiFlexGroup

--- a/public/tabs/chat/messages/message_bubble.tsx
+++ b/public/tabs/chat/messages/message_bubble.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import { IconType } from '@elastic/eui/src/components/icon/icon';
 import { MessageActions } from './message_action';
 import { useCore } from '../../../contexts';
+import { getConfigSchema } from '../../../services';
 
 // TODO: Replace with getChrome().logos.Chat.url
 import { useChatActions } from '../../../hooks';
@@ -123,6 +124,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
     }
 
     const fullWidth = props.message.fullWidth;
+    const configSchema = getConfigSchema();
 
     return (
       <EuiFlexGroup
@@ -159,7 +161,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
                   interaction={props.interaction}
                   message={props.message as IOutput}
                   showFeedback={showFeedback}
-                  showTraceIcon={!!props.message.interactionId}
+                  showTraceIcon={configSchema.chat.trace && !!props.message.interactionId}
+                  traceTip="How was this generated?"
                   traceInteractionId={props.message.interactionId || ''}
                   onViewTrace={() => {
                     const message = props.message as IOutput;


### PR DESCRIPTION
### Description
Add feature flags to traces and feedback.

### Issues Resolved
Add flags in the config to control the trace view and feedback buttons in message bubbles.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
