### PR TITLE
Fix returns 500 error for AI agent APIs when OpenSearch returns 4xx error with json format error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
-- Optimize the response of AI agent APIs ([#373](https://github.com/opensearch-project/dashboards-assistant/pull/373))
+- Optimize the response of AI agent APIs ([#373](https://github.com/opensearch-project/dashboards-assistant/pull/373), [#380](https://github.com/opensearch-project/dashboards-assistant/pull/380))
 - fixed incorrect message id field used ([#378](https://github.com/opensearch-project/dashboards-assistant/pull/378))
 
 ### Infrastructure

--- a/server/routes/agent_routes.test.ts
+++ b/server/routes/agent_routes.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Boom } from '@hapi/boom';
+import { OpenSearchDashboardsRequest, Router } from '../../../../src/core/server/http/router';
+import { enhanceWithContext, triggerHandler } from './router.mock';
+import { resetMocks } from '../services/storage/agent_framework_storage_service.mock';
+import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';
+import { loggerMock } from '../../../../src/core/server/logging/logger.mock';
+import { AGENT_API } from '../../common/constants/llm';
+import { AssistantClient } from '../services/assistant_client';
+import { RequestHandlerContext } from '../../../../src/core/server';
+import { registerAgentRoutes } from './agent_routes';
+const mockedLogger = loggerMock.create();
+
+export const createMockedAssistantClient = (
+  request: OpenSearchDashboardsRequest
+): AssistantClient => {
+  return new AssistantClient(request, {} as RequestHandlerContext);
+};
+
+const mockedAssistantClient = createMockedAssistantClient({} as OpenSearchDashboardsRequest);
+
+describe('test execute agent route', () => {
+  const router = new Router(
+    '',
+    mockedLogger,
+    enhanceWithContext({
+      assistant_plugin: {
+        logger: mockedLogger,
+      },
+    })
+  );
+  registerAgentRoutes(router, {
+    getScopedClient: jest.fn(
+      (request: OpenSearchDashboardsRequest, context: RequestHandlerContext) => {
+        return mockedAssistantClient;
+      }
+    ),
+  });
+  const executeAgentRequest = (payload: {}, query: {}) =>
+    triggerHandler(router, {
+      method: 'post',
+      path: AGENT_API.EXECUTE,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+        query,
+      }),
+    });
+  beforeEach(() => {
+    loggerMock.clear(mockedLogger);
+    resetMocks();
+  });
+
+  it('return 4xx when execute agent throws 4xx error', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: {
+        status: 429,
+        error: {
+          type: 'OpenSearchStatusException',
+          reason: 'System Error',
+          details: 'Request is throttled at model level.',
+        },
+      },
+    });
+    const result = (await executeAgentRequest(
+      {},
+      {
+        agentConfigName: 'os_insight',
+      }
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "{\\"status\\":429,\\"error\\":{\\"type\\":\\"OpenSearchStatusException\\",\\"reason\\":\\"System Error\\",\\"details\\":\\"Request is throttled at model level.\\"}}",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 4xx when executeAgent throws 4xx error in string format', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: 'Request is throttled at model level',
+    });
+    const result = (await executeAgentRequest(
+      {},
+      {
+        agentConfigName: 'os_insight',
+      }
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "Request is throttled at model level",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 5xx when executeAgent throws 5xx error', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 500,
+      body: 'Server error',
+    });
+    const result = (await executeAgentRequest(
+      {},
+      {
+        agentConfigName: 'os_insight',
+      }
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Internal Server Error",
+          "message": "Execute agent failed!",
+          "statusCode": 500,
+        },
+        "statusCode": 500,
+      }
+    `);
+  });
+});

--- a/server/routes/agent_routes.ts
+++ b/server/routes/agent_routes.ts
@@ -42,15 +42,13 @@ export function registerAgentRoutes(router: IRouter, assistantService: Assistant
         context.assistant_plugin.logger.error('Execute agent failed!', e);
         if (e.statusCode >= 400 && e.statusCode <= 499) {
           return res.customError({
-            body: e.body,
+            body: { message: typeof e.body === 'string' ? e.body : JSON.stringify(e.body) },
             statusCode: e.statusCode,
-            headers: e.headers,
           });
         } else {
           return res.customError({
             body: 'Execute agent failed!',
             statusCode: 500,
-            headers: e.headers,
           });
         }
       }

--- a/server/routes/summary_routes.test.ts
+++ b/server/routes/summary_routes.test.ts
@@ -1,0 +1,322 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Boom } from '@hapi/boom';
+import { OpenSearchDashboardsRequest, Router } from '../../../../src/core/server/http/router';
+import { enhanceWithContext, triggerHandler } from './router.mock';
+import { resetMocks } from '../services/storage/agent_framework_storage_service.mock';
+import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';
+import { loggerMock } from '../../../../src/core/server/logging/logger.mock';
+import { SUMMARY_ASSISTANT_API } from '../../common/constants/llm';
+import { registerData2SummaryRoutes, registerSummaryAssistantRoutes } from './summary_routes';
+import { AssistantClient } from '../services/assistant_client';
+import { RequestHandlerContext } from '../../../../src/core/server';
+const mockedLogger = loggerMock.create();
+
+export const createMockedAssistantClient = (
+  request: OpenSearchDashboardsRequest
+): AssistantClient => {
+  return new AssistantClient(request, {} as RequestHandlerContext);
+};
+
+const mockedAssistantClient = createMockedAssistantClient({} as OpenSearchDashboardsRequest);
+
+describe('test summary route', () => {
+  const router = new Router(
+    '',
+    mockedLogger,
+    enhanceWithContext({
+      assistant_plugin: {
+        logger: mockedLogger,
+      },
+    })
+  );
+  registerSummaryAssistantRoutes(router, {
+    getScopedClient: jest.fn(
+      (request: OpenSearchDashboardsRequest, context: RequestHandlerContext) => {
+        return mockedAssistantClient;
+      }
+    ),
+  });
+  registerData2SummaryRoutes(router, {
+    getScopedClient: jest.fn(
+      (request: OpenSearchDashboardsRequest, context: RequestHandlerContext) => {
+        return mockedAssistantClient;
+      }
+    ),
+  });
+  const summaryRequest = (payload: {}) =>
+    triggerHandler(router, {
+      method: 'post',
+      path: SUMMARY_ASSISTANT_API.SUMMARIZE,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+      }),
+    });
+  const insightRequest = (payload: {}) =>
+    triggerHandler(router, {
+      method: 'post',
+      path: SUMMARY_ASSISTANT_API.INSIGHT,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+      }),
+    });
+  const dataToSummaryRequest = (payload: {}) =>
+    triggerHandler(router, {
+      method: 'post',
+      path: SUMMARY_ASSISTANT_API.DATA2SUMMARY,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+      }),
+    });
+  beforeEach(() => {
+    loggerMock.clear(mockedLogger);
+    resetMocks();
+  });
+
+  it('return 4xx when execute agent throws 4xx error for summary API', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: {
+        status: 429,
+        error: {
+          type: 'OpenSearchStatusException',
+          reason: 'System Error',
+          details: 'Request is throttled at model level.',
+        },
+      },
+    });
+    const result = (await summaryRequest({
+      summaryType: 'alerts',
+      insightType: 'user_insight',
+      question: 'Please summarize this alert, do not use any tool.',
+      context: 'context',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "{\\"status\\":429,\\"error\\":{\\"type\\":\\"OpenSearchStatusException\\",\\"reason\\":\\"System Error\\",\\"details\\":\\"Request is throttled at model level.\\"}}",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 4xx when executeAgent throws 4xx error in string format for summary API', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: 'Request is throttled at model level',
+    });
+    const result = (await summaryRequest({
+      summaryType: 'alerts',
+      insightType: 'user_insight',
+      question: 'Please summarize this alert, do not use any tool.',
+      context: 'context',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "Request is throttled at model level",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 5xx when executeAgent throws 5xx error for summary API', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 500,
+      body: 'Server error',
+    });
+    const result = (await summaryRequest({
+      summaryType: 'alerts',
+      insightType: 'user_insight',
+      question: 'Please summarize this alert, do not use any tool.',
+      context: 'context',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Internal Server Error",
+          "message": "Execute agent failed!",
+          "statusCode": 500,
+        },
+        "statusCode": 500,
+      }
+    `);
+  });
+
+  it('return 4xx when execute agent throws 4xx error for insight API', async () => {
+    mockedAssistantClient.executeAgent = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: {
+        status: 429,
+        error: {
+          type: 'OpenSearchStatusException',
+          reason: 'System Error',
+          details: 'Request is throttled at model level.',
+        },
+      },
+    });
+    const result = (await insightRequest({
+      summaryType: 'alerts',
+      insightType: 'test',
+      summary: 'summary',
+      question: 'Please summarize this alert, do not use any tool.',
+      context: 'context',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "{\\"status\\":429,\\"error\\":{\\"type\\":\\"OpenSearchStatusException\\",\\"reason\\":\\"System Error\\",\\"details\\":\\"Request is throttled at model level.\\"}}",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 4xx when executeAgent throws 4xx error in string format for insight API', async () => {
+    mockedAssistantClient.executeAgent = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: 'Request is throttled at model level',
+    });
+    const result = (await insightRequest({
+      summaryType: 'alerts',
+      insightType: 'test',
+      summary: 'summary',
+      question: 'Please summarize this alert, do not use any tool.',
+      context: 'context',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "Request is throttled at model level",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 5xx when executeAgent throws 5xx for insight API', async () => {
+    mockedAssistantClient.executeAgent = jest.fn().mockRejectedValue({
+      statusCode: 500,
+      body: 'Server error',
+    });
+    const result = (await insightRequest({
+      summaryType: 'alerts',
+      insightType: 'test',
+      summary: 'summary',
+      question: 'Please summarize this alert, do not use any tool.',
+      context: 'context',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Internal Server Error",
+          "message": "Execute agent failed!",
+          "statusCode": 500,
+        },
+        "statusCode": 500,
+      }
+    `);
+  });
+
+  it('return 4xx when execute agent throws 4xx error for data2Summary API', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: {
+        status: 429,
+        error: {
+          type: 'OpenSearchStatusException',
+          reason: 'System Error',
+          details: 'Request is throttled at model level.',
+        },
+      },
+    });
+
+    const result = (await dataToSummaryRequest({
+      sample_data: '223.87.60.27 - - [2018-07-22T00:39:02.912Z',
+      sample_count: 1,
+      total_count: 1,
+      question: 'Are there any errors in my logs?',
+      ppl: 'source=opensearch_dashboards_sample_data_logs| head 1',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "{\\"status\\":429,\\"error\\":{\\"type\\":\\"OpenSearchStatusException\\",\\"reason\\":\\"System Error\\",\\"details\\":\\"Request is throttled at model level.\\"}}",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 4xx when executeAgent throws 4xx error in string format for data2Summary API', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: 'Request is throttled at model level',
+    });
+    const result = (await dataToSummaryRequest({
+      sample_data: '223.87.60.27 - - [2018-07-22T00:39:02.912Z',
+      sample_count: 1,
+      total_count: 1,
+      question: 'Are there any errors in my logs?',
+      ppl: 'source=opensearch_dashboards_sample_data_logs| head 1',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "Request is throttled at model level",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 5xx when executeAgent throws 5xx error for data2Summary API', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 500,
+      body: 'Server error',
+    });
+    const result = (await dataToSummaryRequest({
+      sample_data: '223.87.60.27 - - [2018-07-22T00:39:02.912Z',
+      sample_count: 1,
+      total_count: 1,
+      question: 'Are there any errors in my logs?',
+      ppl: 'source=opensearch_dashboards_sample_data_logs| head 1',
+    })) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Internal Server Error",
+          "message": "Execute agent failed!",
+          "statusCode": 500,
+        },
+        "statusCode": 500,
+      }
+    `);
+  });
+});

--- a/server/routes/summary_routes.ts
+++ b/server/routes/summary_routes.ts
@@ -47,7 +47,6 @@ export function registerSummaryAssistantRoutes(
         req.body.index && req.body.dsl && req.body.topNLogPatternData
           ? LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID
           : SUMMARY_AGENT_CONFIG_ID;
-
       let response;
       try {
         response = await assistantClient.executeAgentByConfigName(agentConfigId, {
@@ -61,15 +60,13 @@ export function registerSummaryAssistantRoutes(
         context.assistant_plugin.logger.error('Execute agent failed!', e);
         if (e.statusCode >= 400 && e.statusCode <= 499) {
           return res.customError({
-            body: e.body,
+            body: { message: typeof e.body === 'string' ? e.body : JSON.stringify(e.body) },
             statusCode: e.statusCode,
-            headers: e.headers,
           });
         } else {
           return res.customError({
             body: 'Execute agent failed!',
             statusCode: 500,
-            headers: e.headers,
           });
         }
       }
@@ -150,15 +147,13 @@ export function registerSummaryAssistantRoutes(
         context.assistant_plugin.logger.error('Execute agent failed!', e);
         if (e.statusCode >= 400 && e.statusCode <= 499) {
           return res.customError({
-            body: e.body,
+            body: { message: typeof e.body === 'string' ? e.body : JSON.stringify(e.body) },
             statusCode: e.statusCode,
-            headers: e.headers,
           });
         } else {
           return res.customError({
             body: 'Execute agent failed!',
             statusCode: 500,
-            headers: e.headers,
           });
         }
       }
@@ -228,15 +223,13 @@ export function registerData2SummaryRoutes(
         context.assistant_plugin.logger.error('Execute agent failed!', e);
         if (e.statusCode >= 400 && e.statusCode <= 499) {
           return res.customError({
-            body: e.body,
+            body: { message: typeof e.body === 'string' ? e.body : JSON.stringify(e.body) },
             statusCode: e.statusCode,
-            headers: e.headers,
           });
         } else {
           return res.customError({
             body: 'Execute agent failed!',
             statusCode: 500,
-            headers: e.headers,
           });
         }
       }

--- a/server/routes/text2viz_routes.test.ts
+++ b/server/routes/text2viz_routes.test.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Boom } from '@hapi/boom';
+import { OpenSearchDashboardsRequest, Router } from '../../../../src/core/server/http/router';
+import { enhanceWithContext, triggerHandler } from './router.mock';
+import { resetMocks } from '../services/storage/agent_framework_storage_service.mock';
+import { httpServerMock } from '../../../../src/core/server/http/http_server.mocks';
+import { loggerMock } from '../../../../src/core/server/logging/logger.mock';
+import { TEXT2VIZ_API } from '../../common/constants/llm';
+import { AssistantClient } from '../services/assistant_client';
+import { RequestHandlerContext } from '../../../../src/core/server';
+import { registerText2VizRoutes } from './text2viz_routes';
+const mockedLogger = loggerMock.create();
+
+export const createMockedAssistantClient = (
+  request: OpenSearchDashboardsRequest
+): AssistantClient => {
+  return new AssistantClient(request, {} as RequestHandlerContext);
+};
+
+const mockedAssistantClient = createMockedAssistantClient({} as OpenSearchDashboardsRequest);
+
+describe('test text2viz route', () => {
+  const router = new Router(
+    '',
+    mockedLogger,
+    enhanceWithContext({
+      assistant_plugin: {
+        logger: mockedLogger,
+      },
+    })
+  );
+  registerText2VizRoutes(router, {
+    getScopedClient: jest.fn(
+      (request: OpenSearchDashboardsRequest, context: RequestHandlerContext) => {
+        return mockedAssistantClient;
+      }
+    ),
+  });
+  const text2vizRequest = (payload: {}, query: {}) =>
+    triggerHandler(router, {
+      method: 'post',
+      path: TEXT2VIZ_API.TEXT2VEGA,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+        query,
+      }),
+    });
+  const text2pplRequest = (payload: {}, query: {}) =>
+    triggerHandler(router, {
+      method: 'post',
+      path: TEXT2VIZ_API.TEXT2PPL,
+      req: httpServerMock.createRawRequest({
+        payload: JSON.stringify(payload),
+        query,
+      }),
+    });
+  beforeEach(() => {
+    loggerMock.clear(mockedLogger);
+    resetMocks();
+  });
+
+  it('return 4xx when execute agent throws 4xx error for text2viz', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: {
+        status: 429,
+        error: {
+          type: 'OpenSearchStatusException',
+          reason: 'System Error',
+          details: 'Request is throttled at model level.',
+        },
+      },
+    });
+    const result = (await text2vizRequest(
+      {
+        input_question: 'question',
+        input_instruction: 'instruction',
+        ppl: 'ppl',
+        dataSchema: 'mapping',
+        sampleData: 'sample',
+      },
+      {}
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "{\\"status\\":429,\\"error\\":{\\"type\\":\\"OpenSearchStatusException\\",\\"reason\\":\\"System Error\\",\\"details\\":\\"Request is throttled at model level.\\"}}",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 4xx when executeAgent throws 4xx error in string format for text2viz', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: 'Request is throttled at model level',
+    });
+    const result = (await text2vizRequest(
+      {
+        input_question: 'question',
+        input_instruction: 'instruction',
+        ppl: 'ppl',
+        dataSchema: 'mapping',
+        sampleData: 'sample',
+      },
+      {}
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "Request is throttled at model level",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 5xx when executeAgent throws 5xx error for text2viz', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 500,
+      body: 'Server error',
+    });
+    const result = (await text2vizRequest(
+      {
+        input_question: 'question',
+        input_instruction: 'instruction',
+        ppl: 'ppl',
+        dataSchema: 'mapping',
+        sampleData: 'sample',
+      },
+      {}
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Internal Server Error",
+          "message": "Execute agent failed!",
+          "statusCode": 500,
+        },
+        "statusCode": 500,
+      }
+    `);
+  });
+
+  it('return 4xx when execute agent throws 4xx error for text2ppl', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: {
+        status: 429,
+        error: {
+          type: 'OpenSearchStatusException',
+          reason: 'System Error',
+          details: 'Request is throttled at model level.',
+        },
+      },
+    });
+    const result = (await text2pplRequest(
+      {
+        index: 'index',
+        question: 'question',
+      },
+      {}
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "{\\"status\\":429,\\"error\\":{\\"type\\":\\"OpenSearchStatusException\\",\\"reason\\":\\"System Error\\",\\"details\\":\\"Request is throttled at model level.\\"}}",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 4xx when executeAgent throws 4xx error in string format for text2ppl', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 429,
+      body: 'Request is throttled at model level',
+    });
+    const result = (await text2pplRequest(
+      {
+        index: 'index',
+        question: 'question',
+      },
+      {}
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Too Many Requests",
+          "message": "Request is throttled at model level",
+          "statusCode": 429,
+        },
+        "statusCode": 429,
+      }
+    `);
+  });
+
+  it('return 5xx when executeAgent throws 5xx error for text2ppl', async () => {
+    mockedAssistantClient.executeAgentByConfigName = jest.fn().mockRejectedValue({
+      statusCode: 500,
+      body: 'Server error',
+    });
+    const result = (await text2pplRequest(
+      {
+        index: 'index',
+        question: 'question',
+      },
+      {}
+    )) as Boom;
+    expect(result.output).toMatchInlineSnapshot(`
+      Object {
+        "headers": Object {},
+        "payload": Object {
+          "error": "Internal Server Error",
+          "message": "Execute agent failed!",
+          "statusCode": 500,
+        },
+        "statusCode": 500,
+      }
+    `);
+  });
+});

--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -89,15 +89,13 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         context.assistant_plugin.logger.error('Execute agent failed!', e);
         if (e.statusCode >= 400 && e.statusCode <= 499) {
           return res.customError({
-            body: e.body,
+            body: { message: typeof e.body === 'string' ? e.body : JSON.stringify(e.body) },
             statusCode: e.statusCode,
-            headers: e.headers,
           });
         } else {
           return res.customError({
             body: 'Execute agent failed!',
             statusCode: 500,
-            headers: e.headers,
           });
         }
       }
@@ -131,15 +129,13 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         context.assistant_plugin.logger.error('Execute agent failed!', e);
         if (e.statusCode >= 400 && e.statusCode <= 499) {
           return res.customError({
-            body: e.body,
+            body: { message: typeof e.body === 'string' ? e.body : JSON.stringify(e.body) },
             statusCode: e.statusCode,
-            headers: e.headers,
           });
         } else {
           return res.customError({
             body: 'Execute agent failed!',
             statusCode: 500,
-            headers: e.headers,
           });
         }
       }


### PR DESCRIPTION
### Description
In this PR:https://github.com/opensearch-project/dashboards-assistant/pull/373, we returns 4xx error for the AI agent APIs when the execute agent API in ml-commons plugin responds with a 4xx error, but previously, the execute agent API in ml-commons plugin returns string format error message if the request failed, now it changed to json format, this triggers different condition [here](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/6e851ff33d155e39734707b49a62be4f13ece6ee/src/core/server/http/router/response_adapter.ts#L188) in OSD-core, so we the AI agent APIs return 500 internal error because the custom response body doesn't have a `message` field, this PR fixed the bug.

In addition, when customizing the response, `headers` is not needed because the headers comes from ml-commons API, that is useless for node APIs.

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/0f3625d5-2338-4ebd-b387-343e2ef32819" />

<img width="1240" alt="image" src="https://github.com/user-attachments/assets/ecdd4e78-6001-4b01-8ff4-ab3f18bb410e" />



### Issues Resolved
No issue.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
