### PR TITLE
remove baseUrl config in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "jsx": "react",
     "allowJs": true,
-    "baseUrl": ".",
     "target": "esnext",
     "module": "commonjs",
     "outDir": "./target",


### PR DESCRIPTION
### Description
This `"baseUrl": ".",` is not needed, it prevent us to use path alias such `import {} from "opensearch-dashboards/public"` and `import {} from "opensearch-dashboards/server"`

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
