### PR TITLE
Add query assistant summary switch to the assistant dropdown list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fixed incorrect message id field used ([#378](https://github.com/opensearch-project/dashboards-assistant/pull/378))
 - fix: return 404 instead of 500 for missing agent config name ([#384](https://github.com/opensearch-project/dashboards-assistant/pull/384))
 - Improve alert summary with backend log pattern experience ([#389](https://github.com/opensearch-project/dashboards-assistant/pull/389))
-- Add query assistant summary to the assistant dropdown list ([#395](https://github.com/opensearch-project/dashboards-assistant/pull/395))
 
 ### Infrastructure
 
@@ -28,3 +27,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Maintenance
 
 ### Refactoring
+- Add query assistant summary to the assistant dropdown list ([#395](https://github.com/opensearch-project/dashboards-assistant/pull/395))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fixed incorrect message id field used ([#378](https://github.com/opensearch-project/dashboards-assistant/pull/378))
 - fix: return 404 instead of 500 for missing agent config name ([#384](https://github.com/opensearch-project/dashboards-assistant/pull/384))
 - Improve alert summary with backend log pattern experience ([#389](https://github.com/opensearch-project/dashboards-assistant/pull/389))
+- Add query assistant summary to the assistant dropdown list ([#395](https://github.com/opensearch-project/dashboards-assistant/pull/395))
 
 ### Infrastructure
 

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -18,7 +18,8 @@
   "optionalPlugins": [
     "dataSource",
     "dataSourceManagement",
-    "usageCollection"
+    "usageCollection",
+    "queryEnhancements"
   ],
   "requiredBundles": [],
   "configPath": [

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -24,7 +24,7 @@ import { DataPublicPluginSetup } from '../../../../src/plugins/data/public';
 interface Props {
   data: DataPublicPluginSetup;
   isQuerySummaryCollapsed$: BehaviorSubject<boolean>;
-  isShowQuerySummarySwitch$: BehaviorSubject<boolean>;
+  resultSummaryEnabled$: BehaviorSubject<boolean>;
   label?: string;
 }
 
@@ -37,7 +37,7 @@ export const ActionContextMenu = (props: Props) => {
     datasetType: props.data.query.queryString.getQuery().dataset?.type ?? '',
     dataSourceId: props.data.query.queryString.getQuery().dataset?.dataSource?.id,
   });
-  const isShowQuerySummarySwitch = useObservable(props.isShowQuerySummarySwitch$) || false;
+  const resultSummaryEnabled = useObservable(props.resultSummaryEnabled$) || false;
   const [checked, setChecked] = useState<boolean>(false);
 
   useEffect(() => {
@@ -89,13 +89,13 @@ export const ActionContextMenu = (props: Props) => {
     [actionContext.datasetId, actionContext.datasetType, actionContext.dataSourceId]
   );
 
-  // The action button should be not displayed when there is no action and query summary switch.
-  if (actionsRef.current.length === 0 && !isShowQuerySummarySwitch) {
+  // The action button should be not displayed when there is no action and result summary disabled.
+  if (actionsRef.current.length === 0 && !resultSummaryEnabled) {
     return null;
   }
 
-  // The action button should be disabled when context menu has no item and there is no query summary switch.
-  const actionDisabled = (panels.value?.[0]?.items ?? []).length === 0 && !isShowQuerySummarySwitch;
+  // The action button should be disabled when context menu has no item and result summary disabled.
+  const actionDisabled = (panels.value?.[0]?.items ?? []).length === 0 && !resultSummaryEnabled;
 
   return (
     <EuiPopover
@@ -123,7 +123,7 @@ export const ActionContextMenu = (props: Props) => {
       closePopover={() => setOpen(false)}
     >
       <EuiContextMenu size="s" initialPanelId={'mainMenu'} panels={panels.value} />
-      {isShowQuerySummarySwitch && (
+      {resultSummaryEnabled && (
         <EuiPopoverFooter paddingSize="s">
           <EuiSwitch
             label={i18n.translate('queryEnhancements.queryAssist.summary.switch.label', {

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -37,8 +37,8 @@ export const ActionContextMenu = (props: Props) => {
     datasetType: props.data.query.queryString.getQuery().dataset?.type ?? '',
     dataSourceId: props.data.query.queryString.getQuery().dataset?.dataSource?.id,
   });
-  const resultSummaryEnabled = useObservable(props.resultSummaryEnabled$) || false;
-  const isQuerySummaryCollapsed = useObservable(props.isQuerySummaryCollapsed$) || false;
+  const resultSummaryEnabled = useObservable(props.resultSummaryEnabled$, false);
+  const isQuerySummaryCollapsed = useObservable(props.isQuerySummaryCollapsed$, false);
 
   useEffect(() => {
     const subscription = props.data.query.queryString.getUpdates$().subscribe((query) => {

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -38,7 +38,7 @@ export const ActionContextMenu = (props: Props) => {
     dataSourceId: props.data.query.queryString.getQuery().dataset?.dataSource?.id,
   });
   const resultSummaryEnabled = useObservable(props.resultSummaryEnabled$) || false;
-  const [checked, setChecked] = useState<boolean>(false);
+  const isQuerySummaryCollapsed = useObservable(props.isQuerySummaryCollapsed$) || false;
 
   useEffect(() => {
     const subscription = props.data.query.queryString.getUpdates$().subscribe((query) => {
@@ -55,16 +55,6 @@ export const ActionContextMenu = (props: Props) => {
       subscription.unsubscribe();
     };
   }, [props.data.query.queryString]);
-
-  useEffect(() => {
-    const isQuerySummaryCollapsed = props.isQuerySummaryCollapsed$.getValue();
-    setChecked(!isQuerySummaryCollapsed);
-  }, [props.isQuerySummaryCollapsed$]);
-
-  const onChange = () => {
-    props.isQuerySummaryCollapsed$.next(checked);
-    setChecked(!checked);
-  };
 
   const panels = useAsync(
     () =>
@@ -129,8 +119,8 @@ export const ActionContextMenu = (props: Props) => {
             label={i18n.translate('queryEnhancements.queryAssist.summary.switch.label', {
               defaultMessage: `Show result summarization`,
             })}
-            checked={checked}
-            onChange={() => onChange()}
+            checked={!isQuerySummaryCollapsed}
+            onChange={() => props.isQuerySummaryCollapsed$.next(!isQuerySummaryCollapsed)}
             data-test-subj="queryAssist_summary_switch"
           />
         </EuiPopoverFooter>

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -90,12 +90,25 @@ export const ActionContextMenu = (props: Props) => {
     [actionContext.datasetId, actionContext.datasetType, actionContext.dataSourceId]
   );
 
-  if (actionsRef.current.length === 0) {
+  const isShowQuerySummarySwitch = props.isQuerySummaryEnabled && isASupportedLanguage;
+
+  /**
+   * The action button should be not displayed when the following three situations occur:
+   * 1. There is no action.
+   * 2. Query summary is disabled.
+   * 3. Query summary is enabled and language is not supported.
+   */
+  if (actionsRef.current.length === 0 && !isShowQuerySummarySwitch) {
     return null;
   }
 
-  // If context menu has no item, the action button should be disabled
-  const actionDisabled = (panels.value?.[0]?.items ?? []).length === 0;
+  /**
+   * The action button should be disabled when the following three situations occur:
+   * 1. Context menu has no item.
+   * 2. Query summary is disabled.
+   * 3. Query summary is enabled and language is not supported.
+   */
+  const actionDisabled = (panels.value?.[0]?.items ?? []).length === 0 && !isShowQuerySummarySwitch;
 
   return (
     <EuiPopover
@@ -123,7 +136,7 @@ export const ActionContextMenu = (props: Props) => {
       closePopover={() => setOpen(false)}
     >
       <EuiContextMenu size="s" initialPanelId={'mainMenu'} panels={panels.value} />
-      {props.isQuerySummaryEnabled && isASupportedLanguage && (
+      {isShowQuerySummarySwitch && (
         <EuiPopoverFooter paddingSize="s">
           <EuiSwitch
             label={i18n.translate('queryEnhancements.queryAssist.summary.switch.label', {

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -24,8 +24,7 @@ import { DataPublicPluginSetup } from '../../../../src/plugins/data/public';
 interface Props {
   data: DataPublicPluginSetup;
   isQuerySummaryCollapsed$: BehaviorSubject<boolean>;
-  isQuerySummaryEnabled: boolean;
-  isASupportedLanguage$: BehaviorSubject<boolean>;
+  isShowQuerySummarySwitch$: BehaviorSubject<boolean>;
   label?: string;
 }
 
@@ -38,7 +37,7 @@ export const ActionContextMenu = (props: Props) => {
     datasetType: props.data.query.queryString.getQuery().dataset?.type ?? '',
     dataSourceId: props.data.query.queryString.getQuery().dataset?.dataSource?.id,
   });
-  const isASupportedLanguage = useObservable(props.isASupportedLanguage$) || false;
+  const isShowQuerySummarySwitch = useObservable(props.isShowQuerySummarySwitch$) || false;
   const [checked, setChecked] = useState<boolean>(false);
 
   useEffect(() => {
@@ -89,9 +88,6 @@ export const ActionContextMenu = (props: Props) => {
       }),
     [actionContext.datasetId, actionContext.datasetType, actionContext.dataSourceId]
   );
-
-  // Should show query summary switch when query summary is enabled and users select a supported language.
-  const isShowQuerySummarySwitch = props.isQuerySummaryEnabled && isASupportedLanguage;
 
   // The action button should be not displayed when there is no action and query summary switch.
   if (actionsRef.current.length === 0 && !isShowQuerySummarySwitch) {

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -15,6 +15,7 @@ import {
 import { i18n } from '@osd/i18n';
 
 import { BehaviorSubject } from 'rxjs';
+import { useObservable } from 'react-use';
 import { buildContextMenuForActions } from '../../../../src/plugins/ui_actions/public';
 import { AI_ASSISTANT_QUERY_EDITOR_TRIGGER } from '../ui_triggers';
 import { getUiActions } from '../services';
@@ -37,7 +38,7 @@ export const ActionContextMenu = (props: Props) => {
     datasetType: props.data.query.queryString.getQuery().dataset?.type ?? '',
     dataSourceId: props.data.query.queryString.getQuery().dataset?.dataSource?.id,
   });
-  const [isASupportedLanguage, setIsASupportedLanguage] = useState<boolean>(false);
+  const isASupportedLanguage = useObservable(props.isASupportedLanguage$) || false;
   const [checked, setChecked] = useState<boolean>(false);
 
   useEffect(() => {
@@ -55,16 +56,6 @@ export const ActionContextMenu = (props: Props) => {
       subscription.unsubscribe();
     };
   }, [props.data.query.queryString]);
-
-  useEffect(() => {
-    const subscription = props.isASupportedLanguage$.subscribe((value) => {
-      setIsASupportedLanguage(value);
-    });
-
-    return () => {
-      subscription.unsubscribe();
-    };
-  }, [props.isASupportedLanguage$]);
 
   useEffect(() => {
     const isQuerySummaryCollapsed = props.isQuerySummaryCollapsed$.getValue();

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -90,24 +90,15 @@ export const ActionContextMenu = (props: Props) => {
     [actionContext.datasetId, actionContext.datasetType, actionContext.dataSourceId]
   );
 
+  // Should show query summary switch when query summary is enabled and users select a supported language.
   const isShowQuerySummarySwitch = props.isQuerySummaryEnabled && isASupportedLanguage;
 
-  /**
-   * The action button should be not displayed when the following three situations occur:
-   * 1. There is no action.
-   * 2. Query summary is disabled.
-   * 3. Query summary is enabled and language is not supported.
-   */
+  // The action button should be not displayed when there is no action and query summary switch.
   if (actionsRef.current.length === 0 && !isShowQuerySummarySwitch) {
     return null;
   }
 
-  /**
-   * The action button should be disabled when the following three situations occur:
-   * 1. Context menu has no item.
-   * 2. Query summary is disabled.
-   * 3. Query summary is enabled and language is not supported.
-   */
+  // The action button should be disabled when context menu has no item and there is no query summary switch.
   const actionDisabled = (panels.value?.[0]?.items ?? []).length === 0 && !isShowQuerySummarySwitch;
 
   return (

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -264,11 +264,7 @@ export class AssistantPlugin
       setupChat();
     }
 
-    const {
-      isQuerySummaryCollapsed$,
-      isQuerySummaryEnabled,
-      isASupportedLanguage$,
-    } = setupDeps.queryEnhancements;
+    const { isQuerySummaryCollapsed$, isShowQuerySummarySwitch$ } = setupDeps.queryEnhancements;
     setupDeps.data.__enhance({
       editor: {
         queryEditorExtension: {
@@ -280,8 +276,7 @@ export class AssistantPlugin
               <ActionContextMenu
                 label={this.config.branding.label}
                 isQuerySummaryCollapsed$={isQuerySummaryCollapsed$}
-                isQuerySummaryEnabled={isQuerySummaryEnabled}
-                isASupportedLanguage$={isASupportedLanguage$}
+                isShowQuerySummarySwitch$={isShowQuerySummarySwitch$}
                 data={setupDeps.data}
               />
             );

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -264,7 +264,7 @@ export class AssistantPlugin
       setupChat();
     }
 
-    const { isQuerySummaryCollapsed$, isShowQuerySummarySwitch$ } = setupDeps.queryEnhancements;
+    const { isQuerySummaryCollapsed$, resultSummaryEnabled$ } = setupDeps.queryEnhancements;
     setupDeps.data.__enhance({
       editor: {
         queryEditorExtension: {
@@ -276,7 +276,7 @@ export class AssistantPlugin
               <ActionContextMenu
                 label={this.config.branding.label}
                 isQuerySummaryCollapsed$={isQuerySummaryCollapsed$}
-                isShowQuerySummarySwitch$={isShowQuerySummarySwitch$}
+                resultSummaryEnabled$={resultSummaryEnabled$}
                 data={setupDeps.data}
               />
             );

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -264,6 +264,11 @@ export class AssistantPlugin
       setupChat();
     }
 
+    const {
+      isQuerySummaryCollapsed$,
+      isQuerySummaryEnabled,
+      isASupportedLanguage$,
+    } = setupDeps.queryEnhancements;
     setupDeps.data.__enhance({
       editor: {
         queryEditorExtension: {
@@ -271,7 +276,15 @@ export class AssistantPlugin
           order: 2000,
           isEnabled$: () => of(true),
           getSearchBarButton: () => {
-            return <ActionContextMenu label={this.config.branding.label} data={setupDeps.data} />;
+            return (
+              <ActionContextMenu
+                label={this.config.branding.label}
+                isQuerySummaryCollapsed$={isQuerySummaryCollapsed$}
+                isQuerySummaryEnabled={isQuerySummaryEnabled}
+                isASupportedLanguage$={isASupportedLanguage$}
+                data={setupDeps.data}
+              />
+            );
           },
         },
       },

--- a/public/types.ts
+++ b/public/types.ts
@@ -24,6 +24,7 @@ import {
   UsageCollectionStart,
   UsageCollectionSetup,
 } from '../../../src/plugins/usage_collection/public';
+import { QueryEnhancementsPluginSetup } from '../../../src/plugins/query_enhancements/public';
 
 import { ConfigSchema } from '../common/types/config';
 
@@ -63,6 +64,7 @@ export interface AssistantPluginSetupDependencies {
   usageCollection?: UsageCollectionSetup;
   uiActions: UiActionsSetup;
   expressions: ExpressionsSetup;
+  queryEnhancements: QueryEnhancementsPluginSetup;
 }
 
 export interface AssistantSetup {


### PR DESCRIPTION
### Description
Add query assistant summary to the assistant dropdown list.

This is a follow-up PR for https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9228.
### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
