### PR TITLE
feat: incorporate dynamic config service when reading chat.enabled flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - introduces Pipeline to execute asynchronous operations ([#376](https://github.com/opensearch-project/dashboards-assistant/pull/376))
 - Chatbot entry UI redesign ([#396](https://github.com/opensearch-project/dashboards-assistant/pull/396))
+- expose chatEnabled flag to capabilities ([#398](https://github.com/opensearch-project/dashboards-assistant/pull/398)
 
 ### Enhancements
 

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -226,61 +226,61 @@ export class AssistantPlugin
       });
     }
 
-    if (this.config.chat.enabled) {
-      const setupChat = async () => {
-        const [coreStart, startDeps] = await core.getStartServices();
-        const CoreContext = createOpenSearchDashboardsReactContext<AssistantServices>({
-          ...coreStart,
-          setupDeps,
-          startDeps,
-          conversationLoad: new ConversationLoadService(coreStart.http, this.dataSourceService),
-          conversations: new ConversationsService(coreStart.http, this.dataSourceService),
-          dataSource: this.dataSourceService,
+    (async () => {
+      const [coreStart, startDeps] = await core.getStartServices();
+      if (!coreStart.application.capabilities.assistant?.chatEnabled) {
+        return;
+      }
+      const CoreContext = createOpenSearchDashboardsReactContext<AssistantServices>({
+        ...coreStart,
+        setupDeps,
+        startDeps,
+        conversationLoad: new ConversationLoadService(coreStart.http, this.dataSourceService),
+        conversations: new ConversationsService(coreStart.http, this.dataSourceService),
+        dataSource: this.dataSourceService,
+      });
+      const account = await getAccount();
+      const username = account.user_name;
+
+      if (this.dataSourceService.isMDSEnabled()) {
+        this.resetChatSubscription = this.dataSourceService.dataSourceIdUpdates$.subscribe(() => {
+          assistantActions.resetChat?.();
         });
-        const account = await getAccount();
-        const username = account.user_name;
+      }
 
-        if (this.dataSourceService.isMDSEnabled()) {
-          this.resetChatSubscription = this.dataSourceService.dataSourceIdUpdates$.subscribe(() => {
-            assistantActions.resetChat?.();
-          });
-        }
-
-        if (coreStart.chrome.navGroup.getNavGroupEnabled()) {
-          coreStart.chrome.navControls.registerPrimaryHeaderRight({
-            order: 10000,
-            mount: toMountPoint(
-              <CoreContext.Provider>
-                <HeaderChatButton
-                  application={coreStart.application}
-                  messageRenderers={messageRenderers}
-                  actionExecutors={actionExecutors}
-                  assistantActions={assistantActions}
-                  currentAccount={{ username }}
-                />
-              </CoreContext.Provider>
-            ),
-          });
-        } else {
-          coreStart.chrome.navControls.registerRight({
-            order: 10000,
-            mount: toMountPoint(
-              <CoreContext.Provider>
-                <HeaderChatButton
-                  application={coreStart.application}
-                  messageRenderers={messageRenderers}
-                  actionExecutors={actionExecutors}
-                  assistantActions={assistantActions}
-                  currentAccount={{ username }}
-                  inLegacyHeader
-                />
-              </CoreContext.Provider>
-            ),
-          });
-        }
-      };
-      setupChat();
-    }
+      if (coreStart.chrome.navGroup.getNavGroupEnabled()) {
+        coreStart.chrome.navControls.registerPrimaryHeaderRight({
+          order: 10000,
+          mount: toMountPoint(
+            <CoreContext.Provider>
+              <HeaderChatButton
+                application={coreStart.application}
+                messageRenderers={messageRenderers}
+                actionExecutors={actionExecutors}
+                assistantActions={assistantActions}
+                currentAccount={{ username }}
+              />
+            </CoreContext.Provider>
+          ),
+        });
+      } else {
+        coreStart.chrome.navControls.registerRight({
+          order: 10000,
+          mount: toMountPoint(
+            <CoreContext.Provider>
+              <HeaderChatButton
+                application={coreStart.application}
+                messageRenderers={messageRenderers}
+                actionExecutors={actionExecutors}
+                assistantActions={assistantActions}
+                currentAccount={{ username }}
+                inLegacyHeader
+              />
+            </CoreContext.Provider>
+          ),
+        });
+      }
+    })();
 
     const { isQuerySummaryCollapsed$, resultSummaryEnabled$ } = setupDeps.queryEnhancements;
     setupDeps.data.__enhance({

--- a/server/capabilities.ts
+++ b/server/capabilities.ts
@@ -9,5 +9,6 @@ export const capabilitiesProvider = () => ({
   },
   assistant: {
     enabled: true,
+    chatEnabled: false,
   },
 });

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -80,15 +80,20 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
       const dynamicConfigServiceStart = await core.dynamicConfigService.getStartService();
       const store = dynamicConfigServiceStart.getAsyncLocalStore();
       const client = dynamicConfigServiceStart.getClient();
-      const dynamicConfig = await client.getConfig(
-        { pluginConfigPath: 'assistant' },
-        { asyncLocalStorageContext: store! }
-      );
-      return {
-        assistant: {
-          chatEnabled: dynamicConfig.chat.enabled,
-        },
-      };
+      try {
+        const dynamicConfig = await client.getConfig(
+          { pluginConfigPath: 'assistant' },
+          { asyncLocalStorageContext: store! }
+        );
+        return {
+          assistant: {
+            chatEnabled: dynamicConfig.chat.enabled,
+          },
+        };
+      } catch (e) {
+        this.logger.error(e);
+        return {};
+      }
     });
 
     // Register router for discovery summary

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -19,7 +19,10 @@ import { registerChatRoutes } from './routes/chat_routes';
 import { registerText2VizRoutes } from './routes/text2viz_routes';
 import { AssistantService } from './services/assistant_service';
 import { registerAgentRoutes } from './routes/agent_routes';
-import { registerSummaryAssistantRoutes, registerData2SummaryRoutes } from './routes/summary_routes';
+import {
+  registerSummaryAssistantRoutes,
+  registerData2SummaryRoutes,
+} from './routes/summary_routes';
 import { capabilitiesProvider as visNLQCapabilitiesProvider } from './vis_type_nlq/capabilities_provider';
 import { visNLQSavedObjectType } from './vis_type_nlq/saved_object_type';
 import { capabilitiesProvider } from './capabilities';
@@ -72,7 +75,22 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
     }
 
     core.capabilities.registerProvider(capabilitiesProvider);
-    
+    // register UI capabilities from dynamic config service
+    core.capabilities.registerSwitcher(async () => {
+      const dynamicConfigServiceStart = await core.dynamicConfigService.getStartService();
+      const store = dynamicConfigServiceStart.getAsyncLocalStore();
+      const client = dynamicConfigServiceStart.getClient();
+      const dynamicConfig = await client.getConfig(
+        { pluginConfigPath: 'assistant' },
+        { asyncLocalStorageContext: store! }
+      );
+      return {
+        assistant: {
+          chatEnabled: dynamicConfig.chat.enabled,
+        },
+      };
+    });
+
     // Register router for discovery summary
     registerData2SummaryRoutes(router, assistantServiceSetup);
 


### PR DESCRIPTION
expose assistant.chatEnabled flag to UI capabilities

### Description
[Describe what this change achieves]

Enabled:
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/7a1ae7c8-d9cb-402c-bd81-dc3db663803c" />

Disabled:
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/b83d9724-097b-456d-9bed-ca6ea2dbef94" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
