### PR TITLE
Fix chatbot flyout not show after re-mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fixed incorrect message id field used ([#378](https://github.com/opensearch-project/dashboards-assistant/pull/378))
 - fix: return 404 instead of 500 for missing agent config name ([#384](https://github.com/opensearch-project/dashboards-assistant/pull/384))
 - Improve alert summary with backend log pattern experience ([#389](https://github.com/opensearch-project/dashboards-assistant/pull/389))
+- Fix chatbot flyout not show after re-mount ([#399](https://github.com/opensearch-project/dashboards-assistant/pull/399))
 
 ### Infrastructure
 

--- a/public/chat_header_button.test.tsx
+++ b/public/chat_header_button.test.tsx
@@ -48,6 +48,13 @@ jest.mock('./services', () => {
   };
 });
 
+const sideCarHideMock = jest.fn(() => {
+  const element = document.getElementById('sidecar-mock-div');
+  if (element) {
+    element.style.display = 'none';
+  }
+});
+
 // mock sidecar open,hide and show
 jest.spyOn(coreContextExports, 'useCore').mockReturnValue({
   overlays: {
@@ -62,12 +69,7 @@ jest.spyOn(coreContextExports, 'useCore').mockReturnValue({
             container: attachElement,
           });
         },
-        hide: () => {
-          const element = document.getElementById('sidecar-mock-div');
-          if (element) {
-            element.style.display = 'none';
-          }
-        },
+        hide: sideCarHideMock,
         show: () => {
           const element = document.getElementById('sidecar-mock-div');
           if (element) {
@@ -201,5 +203,27 @@ describe('<HeaderChatButton />', () => {
       metaKey: true,
     });
     expect(screen.getByLabelText('chat input')).not.toHaveFocus();
+  });
+
+  it('should call sidecar hide when button unmount and chat flyout is visible', async () => {
+    const applicationStart = {
+      ...applicationServiceMock.createStartContract(),
+      currentAppId$: new BehaviorSubject(''),
+    };
+    const { unmount, getByLabelText } = render(
+      <HeaderChatButton
+        application={applicationStart}
+        messageRenderers={{}}
+        actionExecutors={{}}
+        assistantActions={{} as AssistantActions}
+        currentAccount={{ username: 'test_user' }}
+      />
+    );
+
+    fireEvent.click(getByLabelText('toggle chat flyout icon'));
+
+    expect(sideCarHideMock).not.toHaveBeenCalled();
+    unmount();
+    expect(sideCarHideMock).toHaveBeenCalled();
   });
 });

--- a/public/chat_header_button.test.tsx
+++ b/public/chat_header_button.test.tsx
@@ -55,6 +55,10 @@ const sideCarHideMock = jest.fn(() => {
   }
 });
 
+const sideCarRefMock = {
+  close: jest.fn(),
+};
+
 // mock sidecar open,hide and show
 jest.spyOn(coreContextExports, 'useCore').mockReturnValue({
   overlays: {
@@ -68,6 +72,7 @@ jest.spyOn(coreContextExports, 'useCore').mockReturnValue({
           render(<MountWrapper mount={mountPoint} />, {
             container: attachElement,
           });
+          return sideCarRefMock;
         },
         hide: sideCarHideMock,
         show: () => {
@@ -205,7 +210,7 @@ describe('<HeaderChatButton />', () => {
     expect(screen.getByLabelText('chat input')).not.toHaveFocus();
   });
 
-  it('should call sidecar hide when button unmount and chat flyout is visible', async () => {
+  it('should call sidecar hide and close when button unmount and chat flyout is visible', async () => {
     const applicationStart = {
       ...applicationServiceMock.createStartContract(),
       currentAppId$: new BehaviorSubject(''),
@@ -223,7 +228,9 @@ describe('<HeaderChatButton />', () => {
     fireEvent.click(getByLabelText('toggle chat flyout icon'));
 
     expect(sideCarHideMock).not.toHaveBeenCalled();
+    expect(sideCarRefMock.close).not.toHaveBeenCalled();
     unmount();
     expect(sideCarHideMock).toHaveBeenCalled();
+    expect(sideCarRefMock.close).toHaveBeenCalled();
   });
 });

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -36,6 +36,7 @@ interface HeaderChatButtonProps {
 }
 
 export const HeaderChatButton = (props: HeaderChatButtonProps) => {
+  const sideCarRef = useRef<{ close: Function }>();
   const [appId, setAppId] = useState<string>();
   const [conversationId, setConversationId] = useState<string>();
   const [title, setTitle] = useState<string>();
@@ -131,7 +132,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
     if (!flyoutLoadedRef.current && flyoutVisible) {
       const mountPoint = flyoutMountPoint.current;
       if (mountPoint) {
-        core.overlays.sidecar().open(mountPoint, {
+        sideCarRef.current = core.overlays.sidecar().open(mountPoint, {
           className: 'chatbot-sidecar',
           config: {
             dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
@@ -176,6 +177,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
       if (flyoutVisibleRef.current) {
         core.overlays.sidecar().hide();
       }
+      sideCarRef.current?.close();
     };
   }, []);
 


### PR DESCRIPTION
### Description
This PR is for fixing chatbot flyout not show after switch to different page header, for more details see videos below.

https://github.com/user-attachments/assets/8098b536-b978-4093-8c15-aa64470dde3c

After this PR, the chat header button component will hide and close sidecar after unmount and re-open sidecar after button click.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
