### PR TITLE
disable rename conversation api using feature flag

### DIFF
--- a/common/types/config.ts
+++ b/common/types/config.ts
@@ -11,6 +11,7 @@ export const configSchema = schema.object({
     enabled: schema.boolean({ defaultValue: false }),
     trace: schema.boolean({ defaultValue: true }),
     feedback: schema.boolean({ defaultValue: true }),
+    allowRenameConversation: schema.boolean({ defaultValue: true }),
   }),
   incontextInsight: schema.object({
     enabled: schema.boolean({ defaultValue: true }),

--- a/public/components/__tests__/chat_window_header_title.test.tsx
+++ b/public/components/__tests__/chat_window_header_title.test.tsx
@@ -15,7 +15,7 @@ import * as useSaveChatExports from '../../hooks/use_save_chat';
 import * as chatContextExports from '../../contexts/chat_context';
 import * as coreContextExports from '../../contexts/core_context';
 import { IMessage } from '../../../common/types/chat_saved_object_attributes';
-
+import * as services from '../../services';
 import { ChatWindowHeaderTitle } from '../chat_window_header_title';
 import { DataSourceServiceMock } from '../../services/data_source_service.mock';
 
@@ -84,7 +84,76 @@ const setup = ({
 };
 
 describe('<ChatWindowHeaderTitle />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should show rename conversation option when feature flag is enabled', () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
+    const { renderResult } = setup();
+    fireEvent.click(renderResult.getByLabelText('toggle chat context menu'));
+    expect(renderResult.getByRole('button', { name: 'Rename conversation' })).toBeInTheDocument();
+  });
+
+  it('should not show rename conversation option when feature flag is disabled', () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: false,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
+    const { renderResult } = setup();
+
+    // Check spy was called
+
+    fireEvent.click(renderResult.getByLabelText('toggle chat context menu'));
+    // Check what's actually rendered
+    console.log('Rendered content:', renderResult.container.innerHTML);
+    expect(
+      renderResult.queryByRole('button', { name: 'Rename conversation' })
+    ).not.toBeInTheDocument();
+  });
   it('should reload history list after edit conversation name', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
     const { renderResult, useCoreMock } = setup();
 
     fireEvent.click(renderResult.getByLabelText('toggle chat context menu'));
@@ -102,6 +171,21 @@ describe('<ChatWindowHeaderTitle />', () => {
   });
 
   it('should show "Rename conversation", "New conversation" and "Save to notebook" actions after title click', () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true, // Feature flag enabled to show rename option
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const { renderResult } = setup();
 
     expect(
@@ -122,6 +206,21 @@ describe('<ChatWindowHeaderTitle />', () => {
   });
 
   it('should show rename modal and hide rename actions after rename button clicked', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true, // Feature flag enabled to allow rename
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const { renderResult } = setup();
 
     fireEvent.click(renderResult.getByLabelText('toggle chat context menu'));
@@ -136,6 +235,22 @@ describe('<ChatWindowHeaderTitle />', () => {
   });
 
   it('should call loadChat with undefined, hide actions and show success toasts after new conversation button clicked', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
     const { renderResult, useCoreMock, useChatActionsMock } = setup();
 
     fireEvent.click(renderResult.getByLabelText('toggle chat context menu'));
@@ -157,6 +272,22 @@ describe('<ChatWindowHeaderTitle />', () => {
   });
 
   it('should show save to notebook modal after "Save to notebook" clicked', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
     const { renderResult } = setup({
       messages: [{ type: 'input', contentType: 'text', content: 'foo' }],
     });

--- a/public/components/__tests__/edit_conversation_name_modal.test.tsx
+++ b/public/components/__tests__/edit_conversation_name_modal.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@osd/i18n/react';
-
+import * as services from '../../services';
 import { coreMock } from '../../../../../src/core/public/mocks';
 import * as coreContextExports from '../../contexts/core_context';
 
@@ -21,6 +21,7 @@ const setup = ({ onClose, defaultTitle, conversationId }: EditConversationNameMo
   const useCoreMock = {
     services: { ...coreMock.createStart(), dataSource: new DataSourceServiceMock() },
   };
+
   jest.spyOn(coreContextExports, 'useCore').mockReturnValue(useCoreMock);
 
   const renderResult = render(
@@ -40,7 +41,55 @@ const setup = ({ onClose, defaultTitle, conversationId }: EditConversationNameMo
 };
 
 describe('<EditConversationNameModal />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not render modal when feature flag is disabled', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: false,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
+    const onCloseMock = jest.fn();
+    setup({
+      conversationId: '1',
+      defaultTitle: 'foo',
+      onClose: onCloseMock,
+    });
+
+    await waitFor(() => {
+      expect(onCloseMock).toHaveBeenCalledWith('cancelled');
+    });
+  });
+
   it('should render default title in name input', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const { renderResult } = setup({
       conversationId: '1',
       defaultTitle: 'foo',
@@ -54,6 +103,21 @@ describe('<EditConversationNameModal />', () => {
   });
 
   it('should call onClose with "canceled" after cancel button click', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onCloseMock = jest.fn();
     const { renderResult, useCoreMock } = setup({
       conversationId: '1',
@@ -77,6 +141,21 @@ describe('<EditConversationNameModal />', () => {
   });
 
   it('should show success toast and call onClose with "updated" after patch conversation succeed', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onCloseMock = jest.fn();
     const { renderResult, useCoreMock } = setup({
       conversationId: '1',
@@ -104,6 +183,21 @@ describe('<EditConversationNameModal />', () => {
   });
 
   it('should show error toasts and call onClose with "errored" after failed patch conversation', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onCloseMock = jest.fn();
     const { renderResult, useCoreMock } = setup({
       conversationId: '1',
@@ -131,6 +225,21 @@ describe('<EditConversationNameModal />', () => {
   });
 
   it('should call onClose with cancelled after patch conversation aborted', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onCloseMock = jest.fn();
     const { renderResult, useCoreMock } = setup({
       conversationId: '1',

--- a/public/components/chat_window_header_title.tsx
+++ b/public/components/chat_window_header_title.tsx
@@ -19,11 +19,13 @@ import { NotebookNameModal } from './notebook/notebook_name_modal';
 import { ChatExperimentalBadge } from './chat_experimental_badge';
 import { useCore } from '../contexts/core_context';
 import { EditConversationNameModal } from './edit_conversation_name_modal';
+import { getConfigSchema } from '../../public/services';
 
 export const ChatWindowHeaderTitle = React.memo(() => {
   const chatContext = useChatContext();
   const { loadChat } = useChatActions();
   const core = useCore();
+  const configSchema = getConfigSchema();
   const [isPopoverOpen, setPopoverOpen] = useState(false);
   const [isRenameModalOpen, setRenameModalOpen] = useState(false);
   const [isSaveNotebookModalOpen, setSaveNotebookModalOpen] = useState(false);
@@ -67,16 +69,18 @@ export const ChatWindowHeaderTitle = React.memo(() => {
   };
 
   const items = [
-    <EuiContextMenuItem
-      disabled={!chatContext.conversationId}
-      key="rename-conversation"
-      onClick={() => {
-        closePopover();
-        setRenameModalOpen(true);
-      }}
-    >
-      Rename conversation
-    </EuiContextMenuItem>,
+    configSchema.chat.allowRenameConversation ? (
+      <EuiContextMenuItem
+        disabled={!chatContext.conversationId}
+        key="rename-conversation"
+        onClick={() => {
+          closePopover();
+          setRenameModalOpen(true);
+        }}
+      >
+        Rename conversation
+      </EuiContextMenuItem>
+    ) : null,
     <EuiContextMenuItem
       key="new-conversation"
       onClick={() => {
@@ -105,7 +109,7 @@ export const ChatWindowHeaderTitle = React.memo(() => {
         Save to notebook
       </EuiContextMenuItem>
     ),
-  ];
+  ].filter((item): item is React.ReactElement => item !== null);
 
   return (
     <>

--- a/public/components/edit_conversation_name_modal.tsx
+++ b/public/components/edit_conversation_name_modal.tsx
@@ -8,6 +8,7 @@ import React, { useCallback, useRef } from 'react';
 import { EuiConfirmModal, EuiCompressedFieldText, EuiSpacer, EuiText } from '@elastic/eui';
 import { useCore } from '../contexts/core_context';
 import { usePatchConversation } from '../hooks';
+import { getConfigSchema } from '../services';
 
 export interface EditConversationNameModalProps {
   onClose?: (status: 'updated' | 'cancelled' | 'errored', newTitle?: string) => void;
@@ -25,6 +26,7 @@ export const EditConversationNameModal = ({
       notifications: { toasts },
     },
   } = useCore();
+  const configSchema = getConfigSchema();
   const titleInputRef = useRef<HTMLInputElement>(null);
   const { loading, abort, patchConversation, isAborted } = usePatchConversation();
 
@@ -50,6 +52,13 @@ export const EditConversationNameModal = ({
     }
     onClose?.('updated', title);
   }, [onClose, conversationId, patchConversation, toasts.addSuccess, toasts.addDanger, isAborted]);
+  console.log('Rename conversation enabled:', configSchema.chat.allowRenameConversation);
+
+  // Move the feature flag check after all hooks are declared
+  if (!configSchema.chat.allowRenameConversation) {
+    onClose?.('cancelled');
+    return null;
+  }
 
   return (
     <EuiConfirmModal

--- a/public/tabs/history/__tests__/chat_history_list.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_list.test.tsx
@@ -7,9 +7,28 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
 import { ChatHistoryList } from '../chat_history_list';
-
+import * as services from '../../../services';
 describe('<ChatHistoryList />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('should render two history titles, update times and one horizontal rule', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
     const { getByText, getAllByLabelText } = render(
       <ChatHistoryList
         chatHistories={[
@@ -27,6 +46,21 @@ describe('<ChatHistoryList />', () => {
   });
 
   it('should call onChatHistoryTitleClick  with id and title', () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onChatHistoryTitleClickMock = jest.fn();
     const { getByText } = render(
       <ChatHistoryList
@@ -41,6 +75,21 @@ describe('<ChatHistoryList />', () => {
   });
 
   it('should call onChatHistoryEditClick with id and title', () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onChatHistoryEditClickMock = jest.fn();
     const { getByLabelText } = render(
       <ChatHistoryList
@@ -55,6 +104,21 @@ describe('<ChatHistoryList />', () => {
   });
 
   it('should call onChatHistoryDeleteClick with id and title', () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onChatHistoryDeleteClickMock = jest.fn();
     const { getByLabelText } = render(
       <ChatHistoryList

--- a/public/tabs/history/__tests__/chat_history_page.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_page.test.tsx
@@ -17,6 +17,7 @@ import * as coreContextExports from '../../../contexts/core_context';
 import { ConversationsService } from '../../../services/conversations_service';
 
 import { ChatHistoryPage } from '../chat_history_page';
+import * as services from '../../../services';
 
 const mockGetConversationsHttp = () => {
   const http = coreMock.createStart().http;
@@ -84,7 +85,25 @@ const setup = ({
 };
 
 describe('<ChatHistoryPage />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('should clear old conversation data after current conversation deleted', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const { renderResult, useChatStateMock, useChatContextMock } = setup({
       http: mockGetConversationsHttp(),
     });
@@ -108,6 +127,21 @@ describe('<ChatHistoryPage />', () => {
   });
 
   it('should render empty screen', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const http = coreMock.createStart().http;
     http.get.mockImplementation(async () => {
       return {
@@ -125,6 +159,54 @@ describe('<ChatHistoryPage />', () => {
           'No conversation has been recorded. Start a conversation in the assistant to have it saved.'
         )
       ).toBeTruthy();
+    });
+  });
+
+  it('should not show edit button when feature flag is disabled', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: false,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
+    const { renderResult } = setup();
+
+    await waitFor(() => {
+      expect(renderResult.queryByLabelText('Edit conversation name')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show edit button when feature flag is enabled', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
+
+    const { renderResult } = setup();
+
+    await waitFor(() => {
+      expect(renderResult.getByLabelText('Edit conversation name')).toBeInTheDocument();
     });
   });
 

--- a/public/tabs/history/__tests__/chat_history_search_list.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_search_list.test.tsx
@@ -10,6 +10,7 @@ import { I18nProvider } from '@osd/i18n/react';
 import { coreMock } from '../../../../../../src/core/public/mocks';
 import * as chatContextExports from '../../../contexts/chat_context';
 import * as coreContextExports from '../../../contexts/core_context';
+import * as services from '../../../services';
 
 import { ChatHistorySearchList, ChatHistorySearchListProps } from '../chat_history_search_list';
 import { DataSourceServiceMock } from '../../../services/data_source_service.mock';
@@ -57,7 +58,25 @@ const setup = ({
 };
 
 describe('<ChatHistorySearchList />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('should set new window title after edit conversation name', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: true,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const { renderResult, useChatContextMock } = setup();
 
     fireEvent.click(renderResult.getByLabelText('Edit conversation name'));
@@ -76,6 +95,21 @@ describe('<ChatHistorySearchList />', () => {
   });
 
   it('should call onRefresh and onHistoryDeleted after conversation deleted', async () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: false,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const onRefreshMock = jest.fn();
     const onHistoryDeletedMock = jest.fn();
 
@@ -100,6 +134,21 @@ describe('<ChatHistorySearchList />', () => {
   });
 
   it('should display empty panel', () => {
+    jest.spyOn(services, 'getConfigSchema').mockReturnValue({
+      enabled: true,
+      chat: {
+        enabled: true,
+        allowRenameConversation: false,
+        trace: true,
+        feedback: true,
+      },
+      incontextInsight: { enabled: true },
+      next: { enabled: false },
+      text2viz: { enabled: false },
+      alertInsight: { enabled: false },
+      smartAnomalyDetector: { enabled: false },
+      branding: { label: undefined, logo: undefined },
+    });
     const { renderResult } = setup({
       histories: [],
     });

--- a/public/tabs/history/chat_history_list.tsx
+++ b/public/tabs/history/chat_history_list.tsx
@@ -14,6 +14,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import moment from 'moment';
+import { getConfigSchema } from '../../services';
 
 interface ChatHistory {
   id: string;
@@ -37,6 +38,9 @@ export const ChatHistoryListItem = ({
   onDeleteClick,
   onEditClick,
 }: ChatHistoryListItemProps) => {
+  const configSchema = getConfigSchema();
+  const showEditButton = configSchema.chat.allowRenameConversation;
+
   const handleTitleClick = useCallback(() => {
     onTitleClick?.(id, title);
   }, [onTitleClick, id, title]);
@@ -74,14 +78,16 @@ export const ChatHistoryListItem = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="s" responsive={false}>
-            <EuiFlexItem grow={false}>
-              <EuiSmallButtonIcon
-                onClick={handleEditClick}
-                iconType="pencil"
-                aria-label="Edit conversation name"
-                color="text"
-              />
-            </EuiFlexItem>
+            {showEditButton && (
+              <EuiFlexItem grow={false}>
+                <EuiSmallButtonIcon
+                  onClick={handleEditClick}
+                  iconType="pencil"
+                  aria-label="Edit conversation name"
+                  color="text"
+                />
+              </EuiFlexItem>
+            )}
             <EuiFlexItem grow={false}>
               <EuiSmallButtonIcon
                 onClick={handleDeleteClick}


### PR DESCRIPTION
### Description
Disable the rename conversation api using feature flag. Upon checking with Binlong and Arjun, disable the api from the frontend is sufficient.

### Issues Resolved
NONE

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
