### PR TITLE
feat: Set logo config in assistant and read logo by config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: Hide navigate to discover button if alert is not from visual editor monitor([#368](https://github.com/opensearch-project/dashboards-assistant/pull/368))
 - Add flags in the config to control trace view and feedback buttons in message bubbles ([#379](https://github.com/opensearch-project/dashboards-assistant/pull/379))
 - feat: Update UI for In-context summarization in Alerts table([#392](https://github.com/opensearch-project/dashboards-assistant/pull/392))
+- Set logo config and read logo by config([#401](https://github.com/opensearch-project/dashboards-assistant/pull/401))
 
 ### Bug Fixes
 

--- a/common/types/config.ts
+++ b/common/types/config.ts
@@ -29,7 +29,12 @@ export const configSchema = schema.object({
   }),
   branding: schema.object({
     label: schema.maybe(schema.string()),
-    logo: schema.maybe(schema.string()),
+    logo: schema.maybe(
+      schema.object({
+        gradient: schema.maybe(schema.string()),
+        gray: schema.maybe(schema.string()),
+      })
+    ),
   }),
 });
 

--- a/public/chat_header_button.test.tsx
+++ b/public/chat_header_button.test.tsx
@@ -16,7 +16,7 @@ import { MountWrapper } from '../../../src/core/public/utils';
 let mockSend: jest.Mock;
 let mockLoadChat: jest.Mock;
 let mockIncontextInsightRegistry: jest.Mock;
-let mockGetConfigSchema: jest.Mock;
+let mockGetLogoIcon: jest.Mock;
 
 jest.mock('./hooks/use_chat_actions', () => {
   mockSend = jest.fn();
@@ -44,16 +44,10 @@ jest.mock('./services', () => {
     on: jest.fn(),
     off: jest.fn(),
   });
-  mockGetConfigSchema = jest.fn().mockReturnValue({
-    branding: {
-      logo: {
-        gray: '',
-      },
-    },
-  });
+  mockGetLogoIcon = jest.fn().mockReturnValue('');
   return {
     getIncontextInsightRegistry: mockIncontextInsightRegistry,
-    getConfigSchema: mockGetConfigSchema,
+    getLogoIcon: mockGetLogoIcon,
   };
 });
 

--- a/public/chat_header_button.test.tsx
+++ b/public/chat_header_button.test.tsx
@@ -16,6 +16,7 @@ import { MountWrapper } from '../../../src/core/public/utils';
 let mockSend: jest.Mock;
 let mockLoadChat: jest.Mock;
 let mockIncontextInsightRegistry: jest.Mock;
+let mockGetConfigSchema: jest.Mock;
 
 jest.mock('./hooks/use_chat_actions', () => {
   mockSend = jest.fn();
@@ -43,8 +44,16 @@ jest.mock('./services', () => {
     on: jest.fn(),
     off: jest.fn(),
   });
+  mockGetConfigSchema = jest.fn().mockReturnValue({
+    branding: {
+      logo: {
+        gray: '',
+      },
+    },
+  });
   return {
     getIncontextInsightRegistry: mockIncontextInsightRegistry,
+    getConfigSchema: mockGetConfigSchema,
   };
 });
 

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -26,6 +26,7 @@ import {
 import { useCore } from './contexts/core_context';
 import { MountPointPortal } from '../../../src/plugins/opensearch_dashboards_react/public';
 import { usePatchFixedStyle } from './hooks/use_patch_fixed_style';
+import { getConfigSchema } from './services';
 
 interface HeaderChatButtonProps {
   application: ApplicationStart;
@@ -49,7 +50,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
   const [inputFocus, setInputFocus] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const registry = getIncontextInsightRegistry();
-
+  const config = getConfigSchema();
   const [sidecarDockedMode, setSidecarDockedMode] = useState(DEFAULT_SIDECAR_DOCKED_MODE);
   const core = useCore();
   const flyoutFullScreen = sidecarDockedMode === SIDECAR_DOCKED_MODE.TAKEOVER;
@@ -60,6 +61,10 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
     const subscription = props.application.currentAppId$.subscribe((id) => setAppId(id));
     return () => subscription.unsubscribe();
   });
+
+  const logoIcon = useMemo(() => {
+    return config?.branding?.logo?.gray ?? chatIcon;
+  }, [config]);
 
   const chatContextValue: IChatContext = useMemo(
     () => ({
@@ -229,8 +234,8 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
           prepend={
             <EuiIcon
               aria-label="toggle chat flyout icon"
-              type={chatIcon}
-              size="l"
+              type={logoIcon}
+              size="m"
               onClick={() => setFlyoutVisible(!flyoutVisible)}
             />
           }

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -9,8 +9,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useEffectOnce } from 'react-use';
 
 import { ApplicationStart, SIDECAR_DOCKED_MODE } from '../../../src/core/public';
-// TODO: Replace with getChrome().logos.Chat.url
-import chatIcon from './assets/chat.svg';
 import { getIncontextInsightRegistry } from './services';
 import { ChatFlyout } from './chat_flyout';
 import { ChatContext, IChatContext } from './contexts/chat_context';
@@ -26,7 +24,7 @@ import {
 import { useCore } from './contexts/core_context';
 import { MountPointPortal } from '../../../src/plugins/opensearch_dashboards_react/public';
 import { usePatchFixedStyle } from './hooks/use_patch_fixed_style';
-import { getConfigSchema } from './services';
+import { getLogoIcon } from './services';
 
 interface HeaderChatButtonProps {
   application: ApplicationStart;
@@ -50,7 +48,6 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
   const [inputFocus, setInputFocus] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const registry = getIncontextInsightRegistry();
-  const config = getConfigSchema();
   const [sidecarDockedMode, setSidecarDockedMode] = useState(DEFAULT_SIDECAR_DOCKED_MODE);
   const core = useCore();
   const flyoutFullScreen = sidecarDockedMode === SIDECAR_DOCKED_MODE.TAKEOVER;
@@ -61,10 +58,6 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
     const subscription = props.application.currentAppId$.subscribe((id) => setAppId(id));
     return () => subscription.unsubscribe();
   });
-
-  const logoIcon = useMemo(() => {
-    return config?.branding?.logo?.gray ?? chatIcon;
-  }, [config]);
 
   const chatContextValue: IChatContext = useMemo(
     () => ({
@@ -234,7 +227,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
           prepend={
             <EuiIcon
               aria-label="toggle chat flyout icon"
-              type={logoIcon}
+              type={getLogoIcon('gray')}
               size="m"
               onClick={() => setFlyoutVisible(!flyoutVisible)}
             />

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -23,17 +23,15 @@ import { useEffectOnce } from 'react-use';
 import { METRIC_TYPE } from '@osd/analytics';
 import { MessageActions } from '../../tabs/chat/messages/message_action';
 import { ContextObj, IncontextInsight as IncontextInsightInput } from '../../types';
-import { getNotifications } from '../../services';
+import { getNotifications, getLogoIcon } from '../../services';
 import { HttpSetup, StartServicesAccessor } from '../../../../../src/core/public';
 import { SUMMARY_ASSISTANT_API } from '../../../common/constants/llm';
-import shiny_sparkle from '../../assets/shiny_sparkle.svg';
 import { UsageCollectionSetup } from '../../../../../src/plugins/usage_collection/public';
 import { reportMetric } from '../../utils/report_metric';
 import { buildUrlQuery, createIndexPatterns, extractTimeRangeDSL } from '../../utils';
 import { AssistantPluginStartDependencies } from '../../types';
 import { UI_SETTINGS } from '../../../../../src/plugins/data/public';
 import { formatUrlWithWorkspaceId } from '../../../../../src/core/public/utils';
-import { ConfigSchema } from '../../../common/types/config';
 
 export const GeneratePopoverBody: React.FC<{
   incontextInsight: IncontextInsightInput;
@@ -41,8 +39,7 @@ export const GeneratePopoverBody: React.FC<{
   usageCollection?: UsageCollectionSetup;
   closePopover: () => void;
   getStartServices?: StartServicesAccessor<AssistantPluginStartDependencies>;
-  config?: ConfigSchema;
-}> = ({ incontextInsight, httpSetup, usageCollection, closePopover, getStartServices, config }) => {
+}> = ({ incontextInsight, httpSetup, usageCollection, closePopover, getStartServices }) => {
   const [summary, setSummary] = useState('');
   const [insight, setInsight] = useState('');
   const [contextObject, setContextObject] = useState<ContextObj | undefined>(undefined);
@@ -54,10 +51,6 @@ export const GeneratePopoverBody: React.FC<{
   const toasts = getNotifications().toasts;
 
   const [displayDiscoverButton, setDisplayDiscoverButton] = useState(false);
-
-  const logoIcon = useMemo(() => {
-    return config?.branding?.logo?.gradient ?? shiny_sparkle;
-  }, [config]);
 
   useEffect(() => {
     const getMonitorType = async () => {
@@ -303,7 +296,12 @@ export const GeneratePopoverBody: React.FC<{
                 color={'text'}
               />
             ) : (
-              <EuiIcon aria-label="alert-assistant" color="hollow" size="m" type={logoIcon} />
+              <EuiIcon
+                aria-label="alert-assistant"
+                color="hollow"
+                size="m"
+                type={getLogoIcon('gradient')}
+              />
             )}
           </EuiFlexItem>
           <EuiFlexItem>

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { i18n } from '@osd/i18n';
 import {
   EuiFlexGroup,
@@ -33,6 +33,7 @@ import { buildUrlQuery, createIndexPatterns, extractTimeRangeDSL } from '../../u
 import { AssistantPluginStartDependencies } from '../../types';
 import { UI_SETTINGS } from '../../../../../src/plugins/data/public';
 import { formatUrlWithWorkspaceId } from '../../../../../src/core/public/utils';
+import { ConfigSchema } from '../../../common/types/config';
 
 export const GeneratePopoverBody: React.FC<{
   incontextInsight: IncontextInsightInput;
@@ -40,7 +41,8 @@ export const GeneratePopoverBody: React.FC<{
   usageCollection?: UsageCollectionSetup;
   closePopover: () => void;
   getStartServices?: StartServicesAccessor<AssistantPluginStartDependencies>;
-}> = ({ incontextInsight, httpSetup, usageCollection, closePopover, getStartServices }) => {
+  config?: ConfigSchema;
+}> = ({ incontextInsight, httpSetup, usageCollection, closePopover, getStartServices, config }) => {
   const [summary, setSummary] = useState('');
   const [insight, setInsight] = useState('');
   const [contextObject, setContextObject] = useState<ContextObj | undefined>(undefined);
@@ -52,6 +54,10 @@ export const GeneratePopoverBody: React.FC<{
   const toasts = getNotifications().toasts;
 
   const [displayDiscoverButton, setDisplayDiscoverButton] = useState(false);
+
+  const logoIcon = useMemo(() => {
+    return config?.branding?.logo?.gradient ?? shiny_sparkle;
+  }, [config]);
 
   useEffect(() => {
     const getMonitorType = async () => {
@@ -297,7 +303,7 @@ export const GeneratePopoverBody: React.FC<{
                 color={'text'}
               />
             ) : (
-              <EuiIcon aria-label="alert-assistant" color="hollow" size="l" type={shiny_sparkle} />
+              <EuiIcon aria-label="alert-assistant" color="hollow" size="m" type={logoIcon} />
             )}
           </EuiFlexItem>
           <EuiFlexItem>

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -26,6 +26,7 @@ import { ContextObj, IncontextInsight as IncontextInsightInput } from '../../typ
 import { getNotifications, getLogoIcon } from '../../services';
 import { HttpSetup, StartServicesAccessor } from '../../../../../src/core/public';
 import { SUMMARY_ASSISTANT_API } from '../../../common/constants/llm';
+import shiny_sparkle from '../../assets/shiny_sparkle.svg';
 import { UsageCollectionSetup } from '../../../../../src/plugins/usage_collection/public';
 import { reportMetric } from '../../utils/report_metric';
 import { buildUrlQuery, createIndexPatterns, extractTimeRangeDSL } from '../../utils';
@@ -300,7 +301,7 @@ export const GeneratePopoverBody: React.FC<{
                 aria-label="alert-assistant"
                 color="hollow"
                 size="m"
-                type={getLogoIcon('gradient')}
+                type={getLogoIcon('gradient', shiny_sparkle)}
               />
             )}
           </EuiFlexItem>

--- a/public/components/incontext_insight/index.tsx
+++ b/public/components/incontext_insight/index.tsx
@@ -25,7 +25,7 @@ import {
   EuiWrappingPopover,
   keys,
 } from '@elastic/eui';
-import React, { Children, isValidElement, useEffect, useRef, useState } from 'react';
+import React, { Children, isValidElement, useEffect, useMemo, useRef, useState } from 'react';
 import { IncontextInsight as IncontextInsightInput } from '../../types';
 import { getIncontextInsightRegistry, getNotifications } from '../../services';
 // TODO: Replace with getChrome().logos.Chat.url
@@ -36,12 +36,14 @@ import { HttpSetup, StartServicesAccessor } from '../../../../../src/core/public
 import { GeneratePopoverBody } from './generate_popover_body';
 import { UsageCollectionSetup } from '../../../../../src/plugins/usage_collection/public/plugin';
 import { AssistantPluginStartDependencies } from '../../types';
+import { ConfigSchema } from '../../../common/types/config';
 
 export interface IncontextInsightProps {
   children?: React.ReactNode;
   httpSetup?: HttpSetup;
   usageCollection?: UsageCollectionSetup;
   getStartServices?: StartServicesAccessor<AssistantPluginStartDependencies>;
+  config?: ConfigSchema;
 }
 
 // TODO: add saved objects / config to store seed suggestions
@@ -50,6 +52,7 @@ export const IncontextInsight = ({
   httpSetup,
   usageCollection,
   getStartServices,
+  config,
 }: IncontextInsightProps) => {
   const anchor = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
@@ -89,6 +92,10 @@ export const IncontextInsight = ({
       }, 1250);
     }
   }, []);
+
+  const logoIcon = useMemo(() => {
+    return config?.branding?.logo?.gradient ?? chatIcon;
+  }, [config]);
 
   const registry = getIncontextInsightRegistry();
   const toasts = getNotifications().toasts;
@@ -275,7 +282,7 @@ export const IncontextInsight = ({
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <div className="incontextInsightAnchorIcon">
-            <EuiIcon type={input.type === 'generate' ? sparkleIcon : chatIcon} size="l" />
+            <EuiIcon type={logoIcon} size="m" />
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -296,6 +303,7 @@ export const IncontextInsight = ({
               usageCollection={usageCollection}
               closePopover={closePopover}
               getStartServices={getStartServices}
+              config={config}
             />
           );
         case 'summary':
@@ -329,7 +337,7 @@ export const IncontextInsight = ({
               <EuiFlexGroup gutterSize="none">
                 <EuiFlexItem>
                   <div>
-                    <EuiBadge color="hollow" iconType={chatIcon} iconSide="left">
+                    <EuiBadge color="hollow" iconType={logoIcon} iconSide="left">
                       {i18n.translate('assistantDashboards.incontextInsight.assistant', {
                         defaultMessage: 'OpenSearch Assistant',
                       })}

--- a/public/components/incontext_insight/index.tsx
+++ b/public/components/incontext_insight/index.tsx
@@ -25,25 +25,21 @@ import {
   EuiWrappingPopover,
   keys,
 } from '@elastic/eui';
-import React, { Children, isValidElement, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Children, isValidElement, useEffect, useRef, useState } from 'react';
 import { IncontextInsight as IncontextInsightInput } from '../../types';
-import { getIncontextInsightRegistry, getNotifications } from '../../services';
-// TODO: Replace with getChrome().logos.Chat.url
-import chatIcon from '../../assets/chat.svg';
+import { getIncontextInsightRegistry, getNotifications, getLogoIcon } from '../../services';
 import sparkle from '../../assets/sparkle.svg';
 import shinySparkle from '../../assets/sparkle_with_gradient.svg';
 import { HttpSetup, StartServicesAccessor } from '../../../../../src/core/public';
 import { GeneratePopoverBody } from './generate_popover_body';
 import { UsageCollectionSetup } from '../../../../../src/plugins/usage_collection/public/plugin';
 import { AssistantPluginStartDependencies } from '../../types';
-import { ConfigSchema } from '../../../common/types/config';
 
 export interface IncontextInsightProps {
   children?: React.ReactNode;
   httpSetup?: HttpSetup;
   usageCollection?: UsageCollectionSetup;
   getStartServices?: StartServicesAccessor<AssistantPluginStartDependencies>;
-  config?: ConfigSchema;
 }
 
 // TODO: add saved objects / config to store seed suggestions
@@ -52,7 +48,6 @@ export const IncontextInsight = ({
   httpSetup,
   usageCollection,
   getStartServices,
-  config,
 }: IncontextInsightProps) => {
   const anchor = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
@@ -92,10 +87,6 @@ export const IncontextInsight = ({
       }, 1250);
     }
   }, []);
-
-  const logoIcon = useMemo(() => {
-    return config?.branding?.logo?.gradient ?? chatIcon;
-  }, [config]);
 
   const registry = getIncontextInsightRegistry();
   const toasts = getNotifications().toasts;
@@ -282,7 +273,7 @@ export const IncontextInsight = ({
         </EuiFlexItem>
         <EuiFlexItem grow={1}>
           <div className="incontextInsightAnchorIcon">
-            <EuiIcon type={logoIcon} size="m" />
+            <EuiIcon type={getLogoIcon('gradient')} size="m" />
           </div>
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -303,7 +294,6 @@ export const IncontextInsight = ({
               usageCollection={usageCollection}
               closePopover={closePopover}
               getStartServices={getStartServices}
-              config={config}
             />
           );
         case 'summary':
@@ -337,7 +327,7 @@ export const IncontextInsight = ({
               <EuiFlexGroup gutterSize="none">
                 <EuiFlexItem>
                   <div>
-                    <EuiBadge color="hollow" iconType={logoIcon} iconSide="left">
+                    <EuiBadge color="hollow" iconType={getLogoIcon('gradient')} iconSide="left">
                       {i18n.translate('assistantDashboards.incontextInsight.assistant', {
                         defaultMessage: 'OpenSearch Assistant',
                       })}

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -28,7 +28,6 @@ import { Text2PPLTask } from '../../utils/pipeline/text_to_ppl_task';
 import { PPLSampleTask } from '../../utils/pipeline/ppl_sample_task';
 import { SourceSelector } from './source_selector';
 import type { IndexPattern } from '../../../../../src/plugins/data/public';
-import chatIcon from '../../assets/chat.svg';
 import { EmbeddableRenderer } from '../../../../../src/plugins/embeddable/public';
 import {
   useOpenSearchDashboards,
@@ -45,7 +44,7 @@ import {
 } from '../../../../../src/plugins/saved_objects/public';
 import { getVisNLQSavedObjectLoader } from '../../vis_nlq/saved_object_loader';
 import { VisNLQSavedObject } from '../../vis_nlq/types';
-import { getIndexPatterns } from '../../services';
+import { getIndexPatterns, getLogoIcon } from '../../services';
 import { NLQ_VISUALIZATION_EMBEDDABLE_TYPE } from './embeddable/nlq_vis_embeddable';
 import { NLQVisualizationInput } from './embeddable/types';
 import { EditorPanel } from './editor_panel';
@@ -129,10 +128,6 @@ export const Text2Viz = () => {
       return undefined;
     }
   }, [editorInput]);
-
-  const logoIcon = useMemo(() => {
-    return config?.branding?.logo?.gray ?? chatIcon;
-  }, [config]);
 
   /**
    * The index pattern of current generated visualization used
@@ -420,7 +415,7 @@ export const Text2Viz = () => {
             onChange={(e) => setInputQuestion(e.target.value)}
             fullWidth
             compressed
-            prepend={<EuiIcon type={logoIcon} />}
+            prepend={<EuiIcon type={getLogoIcon('gray')} />}
             placeholder="Generate visualization with a natural language question."
             onKeyDown={(e) => e.key === 'Enter' && onSubmit()}
             disabled={!selectedSource}
@@ -500,7 +495,7 @@ export const Text2Viz = () => {
                     ) : null}
                     <EuiFlexItem className="text2viz__vizStyleEditorContainer">
                       <VizStyleEditor
-                        iconType={logoIcon}
+                        iconType={getLogoIcon('gray')}
                         onApply={(instruction) => onSubmit(instruction)}
                         value={currentInstruction}
                       />

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -130,6 +130,10 @@ export const Text2Viz = () => {
     }
   }, [editorInput]);
 
+  const logoIcon = useMemo(() => {
+    return config?.branding?.logo?.gray ?? chatIcon;
+  }, [config]);
+
   /**
    * The index pattern of current generated visualization used
    */
@@ -416,7 +420,7 @@ export const Text2Viz = () => {
             onChange={(e) => setInputQuestion(e.target.value)}
             fullWidth
             compressed
-            prepend={<EuiIcon type={config.branding.logo || chatIcon} />}
+            prepend={<EuiIcon type={logoIcon} />}
             placeholder="Generate visualization with a natural language question."
             onKeyDown={(e) => e.key === 'Enter' && onSubmit()}
             disabled={!selectedSource}
@@ -496,7 +500,7 @@ export const Text2Viz = () => {
                     ) : null}
                     <EuiFlexItem className="text2viz__vizStyleEditorContainer">
                       <VizStyleEditor
-                        iconType={config.branding.logo || chatIcon}
+                        iconType={logoIcon}
                         onApply={(instruction) => onSubmit(instruction)}
                         value={currentInstruction}
                       />

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -315,7 +315,6 @@ export class AssistantPlugin
             httpSetup={httpSetup}
             usageCollection={setupDeps.usageCollection}
             getStartServices={core.getStartServices}
-            config={this.config}
           />
         );
       },

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -315,6 +315,7 @@ export class AssistantPlugin
             httpSetup={httpSetup}
             usageCollection={setupDeps.usageCollection}
             getStartServices={core.getStartServices}
+            config={this.config}
           />
         );
       },

--- a/public/services/index.ts
+++ b/public/services/index.ts
@@ -45,6 +45,6 @@ export const [getAssistantService, setAssistantService] = createGetterSetter<Ass
 
 export { DataSourceService, DataSourceServiceContract } from './data_source_service';
 
-export const getLogoIcon = (type: 'gray' | 'gradient') => {
-  return getConfigSchema()?.branding?.logo?.[type] ?? chatIcon;
+export const getLogoIcon = (type: 'gray' | 'gradient', defaultIcon = chatIcon) => {
+  return getConfigSchema()?.branding?.logo?.[type] ?? defaultIcon;
 };

--- a/public/services/index.ts
+++ b/public/services/index.ts
@@ -11,6 +11,7 @@ import { ConfigSchema } from '../../common/types/config';
 import { IndexPatternsContract } from '../../../../src/plugins/data/public';
 import { ExpressionsStart } from '../../../../src/plugins/expressions/public';
 import { AssistantServiceStart } from './assistant_service';
+import chatIcon from '../assets/chat.svg';
 
 export * from './incontext_insight';
 export { ConversationLoadService } from './conversation_load_service';
@@ -43,3 +44,7 @@ export const [getAssistantService, setAssistantService] = createGetterSetter<Ass
 );
 
 export { DataSourceService, DataSourceServiceContract } from './data_source_service';
+
+export const getLogoIcon = (type: 'gray' | 'gradient') => {
+  return getConfigSchema()?.branding?.logo?.[type] ?? chatIcon;
+};

--- a/public/tabs/__tests__/chat_window_header.test.tsx
+++ b/public/tabs/__tests__/chat_window_header.test.tsx
@@ -17,13 +17,7 @@ jest.mock('../../components/chat_window_header_title', () => {
 
 jest.mock('../../services', () => {
   return {
-    getConfigSchema: jest.fn().mockReturnValue({
-      branding: {
-        logo: {
-          gray: '',
-        },
-      },
-    }),
+    getLogoIcon: jest.fn().mockReturnValue(''),
   };
 });
 

--- a/public/tabs/__tests__/chat_window_header.test.tsx
+++ b/public/tabs/__tests__/chat_window_header.test.tsx
@@ -15,6 +15,18 @@ jest.mock('../../components/chat_window_header_title', () => {
   return { ChatWindowHeaderTitle: () => <div>OpenSearch Assistant</div> };
 });
 
+jest.mock('../../services', () => {
+  return {
+    getConfigSchema: jest.fn().mockReturnValue({
+      branding: {
+        logo: {
+          gray: '',
+        },
+      },
+    }),
+  };
+});
+
 const setup = ({ selectedTabId }: { selectedTabId?: TabId } = {}) => {
   const useChatContextMock = {
     conversationId: '1',

--- a/public/tabs/chat/messages/message_bubble.test.tsx
+++ b/public/tabs/chat/messages/message_bubble.test.tsx
@@ -22,6 +22,7 @@ describe('<MessageBubble />', () => {
     jest
       .spyOn(services, 'getConfigSchema')
       .mockReturnValue({ chat: { trace: true, feedback: true } });
+    jest.spyOn(services, 'getLogoIcon').mockReturnValue('');
     jest
       .spyOn(useFeedbackHookExports, 'useFeedback')
       .mockReturnValue({ feedbackResult: undefined, sendFeedback: sendFeedbackMock });

--- a/public/tabs/chat/messages/message_bubble.tsx
+++ b/public/tabs/chat/messages/message_bubble.tsx
@@ -17,11 +17,8 @@ import React from 'react';
 import { IconType } from '@elastic/eui/src/components/icon/icon';
 import { MessageActions } from './message_action';
 import { useCore } from '../../../contexts';
-import { getConfigSchema } from '../../../services';
-
-// TODO: Replace with getChrome().logos.Chat.url
+import { getConfigSchema, getLogoIcon } from '../../../services';
 import { useChatActions } from '../../../hooks';
-import chatIcon from '../../../assets/chat.svg';
 import {
   IMessage,
   IOutput,
@@ -56,8 +53,6 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
     props.message.type === 'output' &&
     props.message.contentType === 'markdown';
 
-  const logoIcon = configSchema?.branding?.logo?.gradient ?? chatIcon;
-
   const createAvatar = (iconType?: IconType) => {
     if (iconType) {
       return (
@@ -70,7 +65,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
         />
       );
     } else {
-      return <EuiIcon type={logoIcon} size="l" />;
+      return <EuiIcon type={getLogoIcon('gradient')} size="l" />;
     }
   };
 

--- a/public/tabs/chat/messages/message_bubble.tsx
+++ b/public/tabs/chat/messages/message_bubble.tsx
@@ -56,6 +56,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
     props.message.type === 'output' &&
     props.message.contentType === 'markdown';
 
+  const logoIcon = configSchema?.branding?.logo?.gradient ?? chatIcon;
+
   const createAvatar = (iconType?: IconType) => {
     if (iconType) {
       return (
@@ -68,7 +70,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = React.memo((props) =>
         />
       );
     } else {
-      return <EuiIcon type={chatIcon} size="l" />;
+      return <EuiIcon type={logoIcon} size="l" />;
     }
   };
 

--- a/public/tabs/chat_window_header.tsx
+++ b/public/tabs/chat_window_header.tsx
@@ -11,9 +11,14 @@ import { ChatWindowHeaderTitle } from '../components/chat_window_header_title';
 import chatIcon from '../assets/chat.svg';
 import { TAB_ID } from '../utils/constants';
 import { SidecarIconMenu } from '../components/sidecar_icon_menu';
+import { getConfigSchema } from '../services';
 
 export const ChatWindowHeader = React.memo(() => {
   const chatContext = useChatContext();
+
+  const configSchema = getConfigSchema();
+
+  const logoIcon = configSchema?.branding?.logo?.gradient ?? chatIcon;
 
   return (
     <>
@@ -26,7 +31,7 @@ export const ChatWindowHeader = React.memo(() => {
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false} style={{ marginLeft: '8px' }}>
-              <EuiIcon type={chatIcon} size="m" />
+              <EuiIcon type={logoIcon} size="m" />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <ChatWindowHeaderTitle />

--- a/public/tabs/chat_window_header.tsx
+++ b/public/tabs/chat_window_header.tsx
@@ -7,18 +7,12 @@ import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui'
 import React from 'react';
 import { useChatContext } from '../contexts/chat_context';
 import { ChatWindowHeaderTitle } from '../components/chat_window_header_title';
-// TODO: Replace with getChrome().logos.Chat.url
-import chatIcon from '../assets/chat.svg';
 import { TAB_ID } from '../utils/constants';
 import { SidecarIconMenu } from '../components/sidecar_icon_menu';
-import { getConfigSchema } from '../services';
+import { getLogoIcon } from '../services';
 
 export const ChatWindowHeader = React.memo(() => {
   const chatContext = useChatContext();
-
-  const configSchema = getConfigSchema();
-
-  const logoIcon = configSchema?.branding?.logo?.gradient ?? chatIcon;
 
   return (
     <>
@@ -31,7 +25,7 @@ export const ChatWindowHeader = React.memo(() => {
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false} style={{ marginLeft: '8px' }}>
-              <EuiIcon type={logoIcon} size="m" />
+              <EuiIcon type={getLogoIcon('gradient')} size="m" />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <ChatWindowHeaderTitle />


### PR DESCRIPTION
### Description
Set logo config in assistant and read logo by config

### Screenshot
![image](https://github.com/user-attachments/assets/7e805f6a-1588-4c18-8ae3-483993c10ee1)
![image](https://github.com/user-attachments/assets/06d7689d-8f48-44bb-943b-6443c0f364d9)
![image](https://github.com/user-attachments/assets/2bd29883-8560-4c7d-8c68-ffdeb5fd7df4)
![image](https://github.com/user-attachments/assets/715e59d7-d570-43b4-9f10-65ac77e1060a)


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
