### PR TITLE
Update dropdown list button label and remove popover title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Refactoring
 - Add query assistant summary to the assistant dropdown list ([#395](https://github.com/opensearch-project/dashboards-assistant/pull/395))
+- Update dropdown list button label and remove popover title ([#407](https://github.com/opensearch-project/dashboards-assistant/pull/407))

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -70,11 +70,7 @@ export const ActionContextMenu = (props: Props) => {
           trigger: AI_ASSISTANT_QUERY_EDITOR_TRIGGER as any,
         })),
         closeMenu: () => setOpen(false),
-        title: props.label
-          ? `${props.label.toUpperCase()} FEATURES`
-          : i18n.translate('dashboardAssistant.branding.assistantActionButton.menu.title', {
-              defaultMessage: 'AI ASSISTANT FEATURES',
-            }),
+        title: props.label ? `${props.label.toUpperCase()} FEATURES` : '',
       }),
     [actionContext.datasetId, actionContext.datasetType, actionContext.dataSourceId]
   );
@@ -92,7 +88,7 @@ export const ActionContextMenu = (props: Props) => {
       button={
         <EuiButtonEmpty
           color="text"
-          aria-label="AI assistant trigger button"
+          aria-label="OpenSearch assistant trigger button"
           size="xs"
           iconType="arrowDown"
           onClick={() => setOpen(!open)}
@@ -103,7 +99,7 @@ export const ActionContextMenu = (props: Props) => {
         >
           {props.label ||
             i18n.translate('dashboardAssistant.branding.assistantActionButton.label', {
-              defaultMessage: 'AI assistant',
+              defaultMessage: 'OpenSearch Assistant',
             })}
         </EuiButtonEmpty>
       }


### PR DESCRIPTION
### Description
Update dropdown list button label and remove popover title
Before:
<img width="432" alt="image" src="https://github.com/user-attachments/assets/9633d07a-a053-456a-b3df-b5a444a166ea" />

After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b1218a81-5db8-4400-b850-cb1d9e4b1891" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
