### PR TITLE
Use feature flag to disable the delete conversation api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: Update UI for In-context summarization in Alerts table([#392](https://github.com/opensearch-project/dashboards-assistant/pull/392))
 - Set logo config and read logo by config([#401](https://github.com/opensearch-project/dashboards-assistant/pull/401))
 - Use feature flag to disable the rename conversation api ([#401](https://github.com/opensearch-project/dashboards-assistant/pull/410))
-- Disable delete conversation api based on feature flag([#402](https://github.com/opensearch-project/dashboards-assistant/pull/402))
+- Disable delete conversation api based on feature flag([#409](https://github.com/opensearch-project/dashboards-assistant/pull/409))
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - feat: Update UI for In-context summarization in Alerts table([#392](https://github.com/opensearch-project/dashboards-assistant/pull/392))
 - Set logo config and read logo by config([#401](https://github.com/opensearch-project/dashboards-assistant/pull/401))
 - Use feature flag to disable the rename conversation api ([#401](https://github.com/opensearch-project/dashboards-assistant/pull/410))
+- Disable delete conversation api based on feature flag([#402](https://github.com/opensearch-project/dashboards-assistant/pull/402))
+
 
 ### Bug Fixes
 

--- a/common/types/config.ts
+++ b/common/types/config.ts
@@ -12,6 +12,7 @@ export const configSchema = schema.object({
     trace: schema.boolean({ defaultValue: true }),
     feedback: schema.boolean({ defaultValue: true }),
     allowRenameConversation: schema.boolean({ defaultValue: true }),
+    deleteConversation: schema.boolean({ defaultValue: true }),
   }),
   incontextInsight: schema.object({
     enabled: schema.boolean({ defaultValue: true }),

--- a/public/components/__tests__/chat_window_header_title.test.tsx
+++ b/public/components/__tests__/chat_window_header_title.test.tsx
@@ -88,6 +88,10 @@ describe('<ChatWindowHeaderTitle />', () => {
     jest.clearAllMocks();
     setupConfigSchemaMock();
   });
+  // There is side effect from setupConfigSchemaMock, need to restore.
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
   it('should show rename conversation option when feature flag enabled', () => {
     const { renderResult } = setup();
     fireEvent.click(renderResult.getByLabelText('toggle chat context menu'));

--- a/public/components/__tests__/edit_conversation_name_modal.test.tsx
+++ b/public/components/__tests__/edit_conversation_name_modal.test.tsx
@@ -47,6 +47,11 @@ describe('<EditConversationNameModal />', () => {
     setupConfigSchemaMock();
   });
 
+  // There is side effect from setupConfigSchemaMock, need to restore.
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should render default title in name input', async () => {
     const { renderResult } = setup({
       conversationId: '1',

--- a/public/components/edit_conversation_name_modal.tsx
+++ b/public/components/edit_conversation_name_modal.tsx
@@ -8,7 +8,6 @@ import React, { useCallback, useRef } from 'react';
 import { EuiConfirmModal, EuiCompressedFieldText, EuiSpacer, EuiText } from '@elastic/eui';
 import { useCore } from '../contexts/core_context';
 import { usePatchConversation } from '../hooks';
-import { getConfigSchema } from '../services';
 
 export interface EditConversationNameModalProps {
   onClose?: (status: 'updated' | 'cancelled' | 'errored', newTitle?: string) => void;
@@ -26,7 +25,6 @@ export const EditConversationNameModal = ({
       notifications: { toasts },
     },
   } = useCore();
-  const configSchema = getConfigSchema();
   const titleInputRef = useRef<HTMLInputElement>(null);
   const { loading, abort, patchConversation, isAborted } = usePatchConversation();
 

--- a/public/tabs/history/__tests__/chat_history_list.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_list.test.tsx
@@ -13,6 +13,11 @@ describe('<ChatHistoryList />', () => {
     setupConfigSchemaMock();
   });
 
+  // There is side effect from setupConfigSchemaMock, need to restore.
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should render two history titles, update times and one horizontal rule', async () => {
     const { getByText, getAllByLabelText } = render(
       <ChatHistoryList

--- a/public/tabs/history/__tests__/chat_history_list.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_list.test.tsx
@@ -5,15 +5,14 @@
 
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-
 import { ChatHistoryList } from '../chat_history_list';
-import * as services from '../../../services';
 import { setupConfigSchemaMock } from '../../../../test/config_schema_mock';
 describe('<ChatHistoryList />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setupConfigSchemaMock();
   });
+
   it('should render two history titles, update times and one horizontal rule', async () => {
     const { getByText, getAllByLabelText } = render(
       <ChatHistoryList
@@ -71,5 +70,19 @@ describe('<ChatHistoryList />', () => {
     expect(onChatHistoryDeleteClickMock).not.toHaveBeenCalled();
     fireEvent.click(getByLabelText('Delete conversation'));
     expect(onChatHistoryDeleteClickMock).toHaveBeenCalledWith({ id: '1' });
+  });
+
+  it('should not show delete button when deleteConversation is disabled', () => {
+    setupConfigSchemaMock({
+      chat: {
+        deleteConversation: false,
+      },
+    });
+
+    const { queryByLabelText } = render(
+      <ChatHistoryList chatHistories={[{ id: '1', title: 'foo', updatedTimeMs: 0 }]} />
+    );
+
+    expect(queryByLabelText('Delete conversation')).not.toBeInTheDocument();
   });
 });

--- a/public/tabs/history/__tests__/chat_history_page.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_page.test.tsx
@@ -89,7 +89,36 @@ describe('<ChatHistoryPage />', () => {
     jest.clearAllMocks();
     setupConfigSchemaMock();
   });
+
+  it('should not show delete button when feature flag is disabled', async () => {
+    setupConfigSchemaMock({
+      chat: { deleteConversation: false },
+    });
+
+    const { renderResult } = setup();
+
+    await waitFor(() => {
+      expect(renderResult.queryByLabelText('Delete conversation')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should show delete button when feature flag is enabled', async () => {
+    setupConfigSchemaMock({
+      chat: { deleteConversation: true },
+    });
+
+    const { renderResult } = setup();
+
+    await waitFor(() => {
+      expect(renderResult.getByLabelText('Delete conversation')).toBeInTheDocument();
+    });
+  });
+
   it('should clear old conversation data after current conversation deleted', async () => {
+    setupConfigSchemaMock({
+      chat: { deleteConversation: true },
+    });
+
     const { renderResult, useChatStateMock, useChatContextMock } = setup({
       http: mockGetConversationsHttp(),
     });

--- a/public/tabs/history/__tests__/chat_history_page.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_page.test.tsx
@@ -90,6 +90,11 @@ describe('<ChatHistoryPage />', () => {
     setupConfigSchemaMock();
   });
 
+  // There is side effect from setupConfigSchemaMock, need to restore.
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should not show delete button when feature flag is disabled', async () => {
     setupConfigSchemaMock({
       chat: { deleteConversation: false },

--- a/public/tabs/history/__tests__/chat_history_page.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_page.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@osd/i18n/react';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { coreMock } from '../../../../../../src/core/public/mocks';
 import { HttpStart } from '../../../../../../src/core/public';

--- a/public/tabs/history/__tests__/chat_history_search_list.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_search_list.test.tsx
@@ -61,6 +61,11 @@ describe('<ChatHistorySearchList />', () => {
     setupConfigSchemaMock();
   });
 
+  // There is side effect from setupConfigSchemaMock, need to restore.
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should not show delete button when deleteConversation is disabled', async () => {
     setupConfigSchemaMock({
       chat: { deleteConversation: false },

--- a/public/tabs/history/__tests__/chat_history_search_list.test.tsx
+++ b/public/tabs/history/__tests__/chat_history_search_list.test.tsx
@@ -6,15 +6,12 @@
 import React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
 import { I18nProvider } from '@osd/i18n/react';
-
 import { coreMock } from '../../../../../../src/core/public/mocks';
 import * as chatContextExports from '../../../contexts/chat_context';
 import * as coreContextExports from '../../../contexts/core_context';
-import * as services from '../../../services';
-
+import { setupConfigSchemaMock } from '../../../../test/config_schema_mock';
 import { ChatHistorySearchList, ChatHistorySearchListProps } from '../chat_history_search_list';
 import { DataSourceServiceMock } from '../../../services/data_source_service.mock';
-import { setupConfigSchemaMock } from '../../../../test/config_schema_mock';
 
 const setup = ({
   loading = false,
@@ -63,6 +60,26 @@ describe('<ChatHistorySearchList />', () => {
     jest.clearAllMocks();
     setupConfigSchemaMock();
   });
+
+  it('should not show delete button when deleteConversation is disabled', async () => {
+    setupConfigSchemaMock({
+      chat: { deleteConversation: false },
+    });
+
+    const { renderResult } = setup();
+
+    expect(renderResult.queryByLabelText('Delete conversation')).not.toBeInTheDocument();
+  });
+
+  it('should show delete button when deleteConversation is enabled', async () => {
+    setupConfigSchemaMock({
+      chat: { deleteConversation: true },
+    });
+    const { renderResult } = setup();
+
+    expect(renderResult.getByLabelText('Delete conversation')).toBeInTheDocument();
+  });
+
   it('should set new window title after edit conversation name', async () => {
     const { renderResult, useChatContextMock } = setup();
 
@@ -83,6 +100,9 @@ describe('<ChatHistorySearchList />', () => {
 
   it('should call onRefresh and onHistoryDeleted after conversation deleted', async () => {
     setupConfigSchemaMock({ chat: { allowRenameConversation: false } });
+    setupConfigSchemaMock({
+      chat: { deleteConversation: true },
+    });
     const onRefreshMock = jest.fn();
     const onHistoryDeletedMock = jest.fn();
 
@@ -110,7 +130,6 @@ describe('<ChatHistorySearchList />', () => {
     const { renderResult } = setup({
       histories: [],
     });
-
     expect(renderResult.getByText('There were no results found.')).toBeInTheDocument();
   });
 });

--- a/public/tabs/history/chat_history_list.tsx
+++ b/public/tabs/history/chat_history_list.tsx
@@ -40,6 +40,7 @@ export const ChatHistoryListItem = ({
 }: ChatHistoryListItemProps) => {
   const configSchema = getConfigSchema();
   const showEditButton = configSchema.chat.allowRenameConversation;
+  const showDeleteButton = configSchema.chat.deleteConversation;
 
   const handleTitleClick = useCallback(() => {
     onTitleClick?.(id, title);
@@ -88,14 +89,16 @@ export const ChatHistoryListItem = ({
                 />
               </EuiFlexItem>
             )}
-            <EuiFlexItem grow={false}>
-              <EuiSmallButtonIcon
-                onClick={handleDeleteClick}
-                iconType="trash"
-                color="danger"
-                aria-label="Delete conversation"
-              />
-            </EuiFlexItem>
+            {showDeleteButton && (
+              <EuiFlexItem grow={false}>
+                <EuiSmallButtonIcon
+                  onClick={handleDeleteClick}
+                  iconType="trash"
+                  color="danger"
+                  aria-label="Delete conversation"
+                />
+              </EuiFlexItem>
+            )}
           </EuiFlexGroup>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/test/config_schema_mock.ts
+++ b/test/config_schema_mock.ts
@@ -26,6 +26,8 @@ export const getMockConfigSchema = (
   branding: { label: undefined, logo: undefined },
 });
 
-export const setupConfigSchemaMock = (overrides: Partial<{ chat: Partial<ChatConfig> }> = {}) => {
+export const setupConfigSchemaMock = (
+  overrides: Partial<{ chat: Partial<ConfigSchema['chat']> }> = {}
+) => {
   jest.spyOn(services, 'getConfigSchema').mockReturnValue(getMockConfigSchema(overrides));
 };

--- a/test/config_schema_mock.ts
+++ b/test/config_schema_mock.ts
@@ -4,11 +4,13 @@
  */
 
 import * as services from '../public/services';
+
 interface ChatConfig {
   enabled: boolean;
   trace: boolean;
   feedback: boolean;
   allowRenameConversation: boolean;
+  deleteConversation: boolean;
 }
 
 interface ConfigSchema {
@@ -33,6 +35,7 @@ export const getMockConfigSchema = (
     trace: true,
     feedback: true,
     allowRenameConversation: true,
+    deleteConversation: true,
     ...(overrides.chat || {}),
   },
   incontextInsight: { enabled: true },

--- a/test/config_schema_mock.ts
+++ b/test/config_schema_mock.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ConfigSchema } from 'common/types/config';
 import * as services from '../public/services';
 interface ChatConfig {
   enabled: boolean;
@@ -12,19 +13,6 @@ interface ChatConfig {
   deleteConversation: boolean;
 }
 
-interface ConfigSchema {
-  enabled: boolean;
-  chat: ChatConfig;
-  incontextInsight: { enabled: boolean };
-  next: { enabled: boolean };
-  text2viz: { enabled: boolean };
-  alertInsight: { enabled: boolean };
-  smartAnomalyDetector: { enabled: boolean };
-  branding: {
-    label: string | undefined;
-    logo: string | undefined;
-  };
-}
 export const getMockConfigSchema = (
   overrides: { chat?: Partial<ChatConfig> } = {}
 ): ConfigSchema => ({

--- a/test/config_schema_mock.ts
+++ b/test/config_schema_mock.ts
@@ -4,7 +4,6 @@
  */
 
 import * as services from '../public/services';
-
 interface ChatConfig {
   enabled: boolean;
   trace: boolean;

--- a/test/config_schema_mock.ts
+++ b/test/config_schema_mock.ts
@@ -5,16 +5,9 @@
 
 import { ConfigSchema } from 'common/types/config';
 import * as services from '../public/services';
-interface ChatConfig {
-  enabled: boolean;
-  trace: boolean;
-  feedback: boolean;
-  allowRenameConversation: boolean;
-  deleteConversation: boolean;
-}
 
 export const getMockConfigSchema = (
-  overrides: { chat?: Partial<ChatConfig> } = {}
+  overrides: { chat?: Partial<ConfigSchema['chat']> } = {}
 ): ConfigSchema => ({
   enabled: true,
   chat: {


### PR DESCRIPTION
### Description
Use feature flag to disable the delete conversation api. 

### Issues Resolved
NONE

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
