### PR TITLE
Adjust footer buttons padding inside alert in-context insight popover panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - remove os_insight agent ([#452](https://github.com/opensearch-project/dashboards-assistant/pull/452))
 - Hide the assistant entry when there isn't data2summary agent ([#417](https://github.com/opensearch-project/dashboards-assistant/pull/417))
+- adjust buttons' padding inside alert in-context insight popover ([#467](https://github.com/opensearch-project/dashboards-assistant/pull/467))
 
 ### Bug Fixes
 

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -363,11 +363,14 @@ export const GeneratePopoverBody: React.FC<{
       {renderInnerTitle()}
       {renderContent()}
       {displayDiscoverButton && (
-        <EuiButton onClick={handleNavigateToDiscover} isLoading={discoverLoading}>
-          {i18n.translate('assistantDashboards.incontextInsight.discover', {
-            defaultMessage: 'Discover details',
-          })}
-        </EuiButton>
+        <>
+          <EuiSpacer size="s" />
+          <EuiButton onClick={handleNavigateToDiscover} isLoading={discoverLoading}>
+            {i18n.translate('assistantDashboards.incontextInsight.discover', {
+              defaultMessage: 'Discover details',
+            })}
+          </EuiButton>
+        </>
       )}
     </>
   );

--- a/public/tabs/chat/messages/message_action.tsx
+++ b/public/tabs/chat/messages/message_action.tsx
@@ -168,7 +168,7 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
       aria-label="message actions"
       className={shouldActionBarVisibleOnHover ? 'llm-chat-action-buttons-hidden' : ''}
       responsive={false}
-      gutterSize="none"
+      gutterSize="xs"
       alignItems="center"
       justifyContent="flexEnd"
     >


### PR DESCRIPTION
### Description

Before:
<img width="516" alt="Screenshot 2025-02-26 at 17 07 04" src="https://github.com/user-attachments/assets/f2cd3c2c-f7f2-4494-8c07-601439c62038" />
After:
<img width="531" alt="Screenshot 2025-02-26 at 17 05 55" src="https://github.com/user-attachments/assets/59395169-ba2e-487d-90a1-fca027b1c38e" />


### Issues Resolved
NA

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [x] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
