### PR TITLE
Add fallback logic for index type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fixed incorrect message id field used ([#378](https://github.com/opensearch-project/dashboards-assistant/pull/378))
 - Improve alert summary with backend log pattern experience ([#389](https://github.com/opensearch-project/dashboards-assistant/pull/389))
 - fixed in context feature returning 500 error if workspace is invalid to returning 4XX ([#429](https://github.com/opensearch-project/dashboards-assistant/pull/429))([#458](https://github.com/opensearch-project/dashboards-assistant/pull/458))
+- Improve error handling for index type detection ([#472](https://github.com/opensearch-project/dashboards-assistant/pull/472))
 
 ### Infrastructure
 

--- a/server/routes/index_type_detect.test.tsx
+++ b/server/routes/index_type_detect.test.tsx
@@ -114,9 +114,9 @@ describe('detectIndexType', () => {
     (getIndexCache as jest.Mock).mockReturnValue(null);
     mockClient.request.mockRejectedValue(new Error('Search failed'));
 
-    await expect(
-      detectIndexType(mockClient, mockAssistantClient, 'test-index', 'test-source')
-    ).rejects.toThrow('Search failed');
+    const result = await detectIndexType(mockClient, mockAssistantClient, 'test-index', undefined);
+
+    expect(result).toBe(false);
   });
 
   it('should handle undefined dataSourceId', async () => {

--- a/server/routes/index_type_detect.tsx
+++ b/server/routes/index_type_detect.tsx
@@ -55,7 +55,7 @@ export async function detectIndexType(
   assistantClient: AssistantClient,
   indexName: string,
   dataSourceId: string | undefined
-) {
+): Promise<boolean> {
   const indexCache = getIndexCache(indexName, dataSourceId ? dataSourceId : '');
   if (indexCache) {
     return indexCache.isLogRelated;
@@ -84,6 +84,8 @@ export async function detectIndexType(
     }
     return false;
   } catch (error) {
-    throw error;
+    console.error('Error detecting index type:', error);
+    // Can not detect index type and return default as is not log related
+    return false;
   }
 }


### PR DESCRIPTION
### Description

Add fallback logic for index type detection, if we can' detect the index is log related then return as not related as default.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
