### PR TITLE
Make sure conversation id been updated before send message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fixed in context feature returning 500 error if workspace is invalid to returning 4XX ([#429](https://github.com/opensearch-project/dashboards-assistant/pull/429))([#458](https://github.com/opensearch-project/dashboards-assistant/pull/458))
 - fix incorrect insight API response ([#473](https://github.com/opensearch-project/dashboards-assistant/pull/473/files))
 - Improve error handling for index type detection ([#472](https://github.com/opensearch-project/dashboards-assistant/pull/472))
+- Fix header button input sending messages to active conversation ([#481](https://github.com/opensearch-project/dashboards-assistant/pull/481))
 
 ### Infrastructure
 

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -110,12 +110,12 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
     ]
   );
 
-  const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const onKeyPress = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && inputRef.current && inputRef.current.value.trim().length > 0) {
       // open chat window
       setFlyoutVisible(true);
       // start a new chat
-      props.assistantActions.loadChat();
+      await props.assistantActions.loadChat();
       // send message
       props.assistantActions.send({
         type: 'input',
@@ -185,7 +185,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
   }, []);
 
   useEffect(() => {
-    const handleSuggestion = (event: {
+    const handleSuggestion = async (event: {
       suggestion: string;
       contextContent: string;
       datasourceId?: string;
@@ -195,7 +195,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
         setFlyoutVisible(true);
       }
       // start a new chat
-      props.assistantActions.loadChat();
+      await props.assistantActions.loadChat();
       // send message
       props.assistantActions.send({
         type: 'input',


### PR DESCRIPTION
### Description
This PR is for fixing header button text input that sometimes sends messages using the active conversation. The root cause was that `conversationId` was not being cleared after `loadChat`. Added `await` after `loadChat` to make sure `conversationId` in chat state has been updated.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
