### PR TITLE
Shrink source selector in t2v page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix incorrect insight API response ([#473](https://github.com/opensearch-project/dashboards-assistant/pull/473/files))
 - Improve error handling for index type detection ([#472](https://github.com/opensearch-project/dashboards-assistant/pull/472))
 - Fix header button input sending messages to active conversation ([#481](https://github.com/opensearch-project/dashboards-assistant/pull/481))
+- Shrink source selector in t2v page ([#492](https://github.com/opensearch-project/dashboards-assistant/pull/492))
 
 ### Infrastructure
 

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -403,7 +403,7 @@ export const Text2Viz = () => {
   const getInputSection = () => {
     return (
       <>
-        <EuiFlexItem grow={3} style={{ maxWidth: '30%' }}>
+        <EuiFlexItem grow={3} style={{ maxWidth: '20vw' }}>
           <SourceSelector
             selectedSourceId={selectedSource}
             onChange={(ds) => setSelectedSource(ds.value)}


### PR DESCRIPTION
### Description
This PR is for shrink source selector in the t2v page when small screen. The root cause was the parent container still hold the extra space when using `max-width: 30%`. Change to a fixed width value can avoid this.

Before
https://github.com/user-attachments/assets/83e39478-7695-41d4-8446-36295b2406d3

After
https://github.com/user-attachments/assets/beb0ec80-b76c-4657-b904-292bd830dea8



### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
