### PR TITLE
Increase search selector width in t2v page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Improve error handling for index type detection ([#472](https://github.com/opensearch-project/dashboards-assistant/pull/472))
 - Fix header button input sending messages to active conversation ([#481](https://github.com/opensearch-project/dashboards-assistant/pull/481))
 - Shrink source selector in t2v page ([#492](https://github.com/opensearch-project/dashboards-assistant/pull/492))
+- Increase search selector width in t2v page ([#495](https://github.com/opensearch-project/dashboards-assistant/pull/495))
 
 ### Infrastructure
 

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -403,13 +403,13 @@ export const Text2Viz = () => {
   const getInputSection = () => {
     return (
       <>
-        <EuiFlexItem grow={3} style={{ maxWidth: '20vw' }}>
+        <EuiFlexItem grow={2} style={{ maxWidth: '35vw' }}>
           <SourceSelector
             selectedSourceId={selectedSource}
             onChange={(ds) => setSelectedSource(ds.value)}
           />
         </EuiFlexItem>
-        <EuiFlexItem grow={8}>
+        <EuiFlexItem grow={1}>
           <EuiFieldText
             value={inputQuestion}
             onChange={(e) => setInputQuestion(e.target.value)}


### PR DESCRIPTION
### Description
This PR is for increasing search selector width in t2v page.
- Screen width 1728
<img width="1722" alt="image" src="https://github.com/user-attachments/assets/6869b184-434b-4841-b775-40980977536e" />
- Screen width1200
<img width="1201" alt="image" src="https://github.com/user-attachments/assets/cd396f68-8f4c-4d24-90df-c5c6ab04c134" />
- Screen width 890
<img width="888" alt="image" src="https://github.com/user-attachments/assets/32cf6ea0-d532-4b1c-94d1-7266c50c0f28" />



### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
