### PR TITLE
Fix bottom spacing for chatbot flyout's input box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix header button input sending messages to active conversation ([#481](https://github.com/opensearch-project/dashboards-assistant/pull/481))
 - Shrink source selector in t2v page ([#492](https://github.com/opensearch-project/dashboards-assistant/pull/492))
 - Increase search selector width in t2v page ([#495](https://github.com/opensearch-project/dashboards-assistant/pull/495))
+- Fix bottom spacing for chatbot flyout's input box ([#496](https://github.com/opensearch-project/dashboards-assistant/pull/496))
 - Fix incontext insight popover close ([#498](https://github.com/opensearch-project/dashboards-assistant/pull/498))
 - Fix error handling for data source connection errors ([#500](https://github.com/opensearch-project/dashboards-assistant/pull/500))
 

--- a/public/index.scss
+++ b/public/index.scss
@@ -9,7 +9,7 @@
   position: relative;
   width: 200px;
 
-  &.in-legacy-header{
+  &.in-legacy-header {
     margin: 0 $euiSizeS;
     height: $euiSizeL * 2;
   }
@@ -20,17 +20,17 @@
     }
   }
 
-  .llm-chat-header-text-input{
+  .llm-chat-header-text-input {
     padding-left: $euiSizeXL;
     padding-right: $euiSizeL * 2;
   }
 
-  .llm-chat-toggle-icon{
+  .llm-chat-toggle-icon {
     position: absolute;
     left: $euiSizeS;
   }
 
-  .llm-chat-header-shortcut{
+  .llm-chat-header-shortcut {
     position: absolute;
     right: $euiSizeS;
   }
@@ -49,6 +49,8 @@
 
 .llm-chat-flyout {
   height: 100%;
+  display: flex;
+  flex-direction: column;
   .euiFlyoutFooter {
     background: transparent;
   }
@@ -71,10 +73,6 @@
   background-color: $euiPageBackgroundColor;
   margin: 8px;
   border-radius: 8px;
-}
-
-.llm-chat-flyout-footer {
-  padding-bottom: 24px;
 }
 
 .llm-chat-bubble-wrapper {

--- a/public/tabs/chat/chat_page.tsx
+++ b/public/tabs/chat/chat_page.tsx
@@ -93,13 +93,13 @@ export const ChatPage: React.FC<ChatPageProps> = (props) => {
           </EuiPageBody>
         </EuiPage>
       </EuiFlyoutBody>
-      <EuiFlyoutFooter className="llm-chat-flyout-footer">
+      <EuiFlyoutFooter>
         <EuiSpacer size="xs" />
         <ChatInputControls
           loading={chatState.llmResponding}
           disabled={messagesLoading || chatState.llmResponding}
         />
-        <EuiSpacer size="s" />
+        <EuiSpacer size="m" />
       </EuiFlyoutFooter>
     </>
   );


### PR DESCRIPTION
### Description

Add additional 16px padding to the bottom

Before:
<img width="467" alt="Screenshot 2025-03-10 at 10 31 37" src="https://github.com/user-attachments/assets/ed16355e-fdd1-491e-b346-cf467de19159" />
After:
<img width="471" alt="Screenshot 2025-03-10 at 10 32 25" src="https://github.com/user-attachments/assets/0cb6ca86-3533-4d78-8a4a-2ba19aade422" />


### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
