### PR TITLE
Fix incontext insight popover close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix header button input sending messages to active conversation ([#481](https://github.com/opensearch-project/dashboards-assistant/pull/481))
 - Shrink source selector in t2v page ([#492](https://github.com/opensearch-project/dashboards-assistant/pull/492))
 - Increase search selector width in t2v page ([#495](https://github.com/opensearch-project/dashboards-assistant/pull/495))
+- Fix incontext insight popover close ([#498](https://github.com/opensearch-project/dashboards-assistant/pull/498))
 
 ### Infrastructure
 

--- a/public/components/incontext_insight/index.tsx
+++ b/public/components/incontext_insight/index.tsx
@@ -50,6 +50,7 @@ export const IncontextInsight = ({
   getStartServices,
 }: IncontextInsightProps) => {
   const anchor = useRef<HTMLDivElement>(null);
+  const anchorButton = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
   const [isHover, setIsHover] = useState(false);
 
@@ -281,6 +282,7 @@ export const IncontextInsight = ({
             }}
             tabIndex={0}
             role="button"
+            ref={anchorButton}
           >
             <EuiIcon type={getLogoIcon('gradient')} size="m" />
           </div>
@@ -290,7 +292,7 @@ export const IncontextInsight = ({
   };
 
   const renderPopover = () => {
-    if (!input || !target || !anchor.current) return;
+    if (!input || !target || !anchor.current || !anchorButton.current) return;
     const popoverBody = () => {
       switch (input.type) {
         case 'suggestions':
@@ -321,7 +323,7 @@ export const IncontextInsight = ({
     return (
       <EuiWrappingPopover
         key={input.key}
-        button={anchor.current?.firstChild as HTMLElement}
+        button={anchorButton.current}
         isOpen={isVisible}
         closePopover={closePopover}
         anchorClassName="incontextInsightAnchor"


### PR DESCRIPTION
### Description
This PR fixes incontext insight popover can't close after click the alert title.
![image](https://github.com/user-attachments/assets/1e3c4391-b7b4-4f54-8058-8a2a81b6fbc5)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
