### PR TITLE
Add http error instruction for t2ppl task

### DIFF
--- a/public/utils/pipeline/text_to_ppl_task.test.ts
+++ b/public/utils/pipeline/text_to_ppl_task.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { processInputQuestion } from './text_to_ppl_task';
+
+describe('processInputQuestion', () => {
+  it('should return consistent instructions if error or fail keyword exists', () => {
+    expect(processInputQuestion('show me Errors by day in the last 7 days?')).toMatchInlineSnapshot(
+      `"show me Errors by day in the last 7 days?. If you're dealing logs with http response code, then error usually refers to http response code like 4xx, 5xx"`
+    );
+
+    expect(processInputQuestion('how many Failed logs in January')).toMatchInlineSnapshot(
+      `"how many Failed logs in January. If you're dealing logs with http response code, then error usually refers to http response code like 4xx, 5xx"`
+    );
+  });
+
+  it('should return consistent instructions if no error or fail keyword exists', () => {
+    expect(processInputQuestion('how many orders are sold every day')).toMatchInlineSnapshot(
+      `"how many orders are sold every day"`
+    );
+  });
+});

--- a/public/utils/pipeline/text_to_ppl_task.ts
+++ b/public/utils/pipeline/text_to_ppl_task.ts
@@ -7,6 +7,14 @@ import { HttpSetup } from '../../../../../src/core/public';
 import { Task } from './task';
 import { TEXT2VIZ_API } from '../../../common/constants/llm';
 
+export const processInputQuestion = (inputQuestion: string) => {
+  const httpErrorErrorAppendRegExp = new RegExp(`(?:${['error', 'fail'].join('|')})`, 'i');
+  if (httpErrorErrorAppendRegExp.test(inputQuestion)) {
+    return `${inputQuestion}. If you're dealing logs with http response code, then error usually refers to http response code like 4xx, 5xx`;
+  }
+  return inputQuestion;
+};
+
 interface Input {
   inputQuestion: string;
   index: string;
@@ -24,7 +32,7 @@ export class Text2PPLTask extends Task<Input, Input & { ppl: string }> {
   async execute<T extends Input>(v: T) {
     let ppl = '';
     try {
-      ppl = await this.text2ppl(v.inputQuestion, v.index, v.dataSourceId);
+      ppl = await this.text2ppl(processInputQuestion(v.inputQuestion), v.index, v.dataSourceId);
     } catch (e) {
       throw new Error(
         `Error while generating PPL query with input: ${v.inputQuestion}. Please try rephrasing your question.`


### PR DESCRIPTION
### Description
This PR will append http error instruction when t2v input question contains error or fail.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
