### PR TITLE
Fix alert summary message action position when no discover button

### DIFF
--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -331,7 +331,10 @@ export const GeneratePopoverBody: React.FC<{
           </EuiButton>
         )}
         {
-          <div style={{ display: showInsight ? 'none' : 'block' }}>
+          <div
+            className="messageActionsWrapper"
+            style={{ display: showInsight ? 'none' : 'block' }}
+          >
             <MessageActions
               contentToCopy={summary}
               showFeedback
@@ -346,7 +349,10 @@ export const GeneratePopoverBody: React.FC<{
           </div>
         }
         {
-          <div style={{ display: showInsight && insightAvailable ? 'block' : 'none' }}>
+          <div
+            className="messageActionsWrapper"
+            style={{ display: showInsight && insightAvailable ? 'block' : 'none' }}
+          >
             <MessageActions
               contentToCopy={insight}
               showFeedback

--- a/public/components/incontext_insight/index.scss
+++ b/public/components/incontext_insight/index.scss
@@ -122,6 +122,10 @@
     border-left: $euiBorderThin;
     margin: 0 2px;
   }
+
+  .messageActionsWrapper {
+    flex-grow: 1;
+  }
 }
 
 .incontextInsightGeneratePopoverContent {


### PR DESCRIPTION
### Description
Fix the regression of action button group when there is no discover button that introduced in the previous PR

Problem:
![image](https://github.com/user-attachments/assets/04940ed0-ffc3-45cf-ac91-8c1e67c737a3)
Fix:
<img width="543" alt="Screenshot 2025-03-13 at 11 32 56" src="https://github.com/user-attachments/assets/f6360ae2-2ecb-4e96-855a-608d38330dba" />


Before: 

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
