### PR TITLE
Generate visualization on t2v page mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Features
 
+- Generate visualization on t2v page mount ([#505](https://github.com/opensearch-project/dashboards-assistant/pull/505))
 
 ### Enhancements
 

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -21,7 +21,7 @@ import { i18n } from '@osd/i18n';
 import { v4 as uuidv4 } from 'uuid';
 
 import { useCallback } from 'react';
-import { useObservable } from 'react-use';
+import { useEffectOnce, useObservable } from 'react-use';
 import { useLocation, useParams } from 'react-router-dom';
 import { Pipeline } from '../../utils/pipeline/pipeline';
 import { Text2PPLTask } from '../../utils/pipeline/text_to_ppl_task';
@@ -400,6 +400,13 @@ export const Text2Viz = () => {
       chrome.setHeaderVariant();
     };
   }, [chrome]);
+
+  useEffectOnce(() => {
+    if (!selectedSource || !inputQuestion) {
+      return;
+    }
+    onSubmit();
+  });
 
   const factory = embeddable.getEmbeddableFactory<NLQVisualizationInput>(
     NLQ_VISUALIZATION_EMBEDDABLE_TYPE


### PR DESCRIPTION
### Description
This PR add a feature that generate visualization on t2v page mount when search source and input question exists in the search parameters.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
