### PR TITLE
fix: remove text in badge to make it compatible with small screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Features
 
-
 ### Enhancements
 
 ### Bug Fixes
+
+- Remove text in badge to make it compatible with small screen ([#509](https://github.com/opensearch-project/dashboards-assistant/pull/509))
 
 ### Infrastructure
 

--- a/public/components/incontext_insight/index.scss
+++ b/public/components/incontext_insight/index.scss
@@ -45,11 +45,10 @@
 
   .summary-beta-badge {
     margin-left: 8px;
-  }
-
-  .summary_badge_icon {
-    filter: brightness(100);
-    height: 24px;
+    cursor: pointer;
+    .euiBetaBadge__icon {
+      filter: brightness(100);
+    }
   }
 }
 

--- a/public/components/incontext_insight/index.scss
+++ b/public/components/incontext_insight/index.scss
@@ -44,7 +44,7 @@
   margin: 0 -2px -5px -5px;
 
   .summary-beta-badge {
-    margin-left: 8px;
+    margin-left: 4px;
     cursor: pointer;
     .euiBetaBadge__icon {
       filter: brightness(100);

--- a/public/components/incontext_insight/index.tsx
+++ b/public/components/incontext_insight/index.tsx
@@ -289,22 +289,10 @@ export const IncontextInsight = ({
             ref={anchorButton}
           >
             <EuiBetaBadge
-              title={title}
+              label={title}
               style={{ backgroundColor: euiThemeVars.euiColorInk }}
               className="summary-beta-badge"
-              size="s"
-              label={
-                <EuiButtonEmpty
-                  iconType={getLogoIcon('gradient')}
-                  iconSize="s"
-                  color="text"
-                  className="summary_badge_icon"
-                >
-                  <EuiText color="ghost" size="s">
-                    {title}
-                  </EuiText>
-                </EuiButtonEmpty>
-              }
+              iconType={getLogoIcon('gradient')}
             />
           </div>
         </EuiFlexItem>


### PR DESCRIPTION
### Description
Oui badge doesn't support resize and the minimum size of it will overlap in alerting table, remove text in badge to make it compatible with small screen. Will update this once confirmed with UX for a more complete solution.

### Screenshot
![image](https://github.com/user-attachments/assets/192263be-9c2f-4496-a8c4-abd77df04f6c)
![image](https://github.com/user-attachments/assets/905338df-90ba-495e-9962-01015d42220e)


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
