### PR TITLE
chatbot dock bottom border top

### DIFF
--- a/public/chat_flyout.tsx
+++ b/public/chat_flyout.tsx
@@ -12,6 +12,7 @@ import { ChatWindowHeader } from './tabs/chat_window_header';
 import { ChatHistoryPage } from './tabs/history/chat_history_page';
 import { AgentFrameworkTracesFlyoutBody } from './components/agent_framework_traces_flyout_body';
 import { TAB_ID } from './utils/constants';
+import { SIDECAR_DOCKED_MODE } from '../../../src/core/public';
 
 interface ChatFlyoutProps {
   flyoutVisible: boolean;
@@ -77,12 +78,17 @@ export const ChatFlyout = (props: ChatFlyoutProps) => {
 
   const leftPanelSize = getLeftPanelSize();
   const rightPanelSize = getRightPanelSize();
+  const { sidecarDockedMode } = useChatContext();
 
   return (
     <div
-      className={cs('llm-chat-flyout', {
-        'llm-chat-fullscreen': props.flyoutFullScreen,
-      })}
+      className={cs(
+        'llm-chat-flyout',
+        {
+          'llm-chat-fullscreen': props.flyoutFullScreen,
+        },
+        { 'llm-chatbot-border-top': sidecarDockedMode === SIDECAR_DOCKED_MODE.TAKEOVER }
+      )}
     >
       <>
         <div className={cs('llm-chat-flyout-header')}>

--- a/public/index.scss
+++ b/public/index.scss
@@ -63,6 +63,10 @@
   }
 }
 
+.llm-chatbot-border-top {
+  border-top: 1px solid $ouiBorderColor;
+}
+
 .llm-chat-flyout-header {
   padding-top: 4px;
 }


### PR DESCRIPTION
### Description
No way to tell the dock border from the underlying app, added a line between dock bottom and border top

### Issues Resolved
![Screenshot 2025-03-17 at 16 53 40](https://github.com/user-attachments/assets/d1d047c5-439f-460c-83e2-bdcfd9f09a35)



### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
