### PR TITLE
Add auto aggregation suggest for t2v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Enhancements
 
+- Add auto suggested aggregation for text2Viz ([#514](https://github.com/opensearch-project/dashboards-assistant/pull/514))
+
 ### Bug Fixes
 
 ### Infrastructure

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -26,6 +26,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import { Pipeline } from '../../utils/pipeline/pipeline';
 import { Text2PPLTask } from '../../utils/pipeline/text_to_ppl_task';
 import { PPLSampleTask } from '../../utils/pipeline/ppl_sample_task';
+import { PPLAutoSuggestTask } from '../../utils/pipeline/ppl_aggs_auto_suggest_task';
 import { SourceSelector } from './source_selector';
 import type { IndexPattern } from '../../../../../src/plugins/data/public';
 import { EmbeddableRenderer } from '../../../../../src/plugins/embeddable/public';
@@ -111,6 +112,7 @@ export const Text2Viz = () => {
   if (text2vegaRef.current === null) {
     text2vegaRef.current = new Pipeline([
       new Text2PPLTask(http),
+      new PPLAutoSuggestTask(data.search),
       new PPLSampleTask(data.search),
       new Text2VegaTask(http, savedObjects),
     ]);
@@ -252,6 +254,7 @@ export const Text2Viz = () => {
         inputQuestion,
         inputInstruction,
         dataSourceId: indexPattern.dataSourceRef?.id,
+        timeFiledName: indexPattern.timeFieldName,
       });
 
       if (usageCollection) {

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -26,7 +26,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import { Pipeline } from '../../utils/pipeline/pipeline';
 import { Text2PPLTask } from '../../utils/pipeline/text_to_ppl_task';
 import { PPLSampleTask } from '../../utils/pipeline/ppl_sample_task';
-import { PPLAutoSuggestTask } from '../../utils/pipeline/ppl_aggs_auto_suggest_task';
+import { PPLAggsAutoSuggestTask } from '../../utils/pipeline/ppl_aggs_auto_suggest_task';
 import { SourceSelector } from './source_selector';
 import type { IndexPattern } from '../../../../../src/plugins/data/public';
 import { EmbeddableRenderer } from '../../../../../src/plugins/embeddable/public';
@@ -112,7 +112,7 @@ export const Text2Viz = () => {
   if (text2vegaRef.current === null) {
     text2vegaRef.current = new Pipeline([
       new Text2PPLTask(http),
-      new PPLAutoSuggestTask(data.search),
+      new PPLAggsAutoSuggestTask(data.search),
       new PPLSampleTask(data.search),
       new Text2VegaTask(http, savedObjects),
     ]);

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
+import { PPLAutoSuggestTask } from './ppl_aggs_auto_suggest_task';
+
+describe('PPLAutoSuggestTask', () => {
+  let pplAutoSuggestTask: PPLAutoSuggestTask;
+  let mockSearchClient: DataPublicPluginStart['search'];
+
+  beforeEach(() => {
+    // Mock the search client
+    mockSearchClient = {
+      search: jest.fn(),
+      aggs: {
+        calculateAutoTimeExpression: jest.fn(),
+      },
+    };
+    pplAutoSuggestTask = new PPLAutoSuggestTask(mockSearchClient);
+  });
+
+  it('should return original input if PPL is empty', async () => {
+    const input = {
+      ppl: '',
+      dataSourceId: 'test-source',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should return original input if PPL already has aggregation', async () => {
+    const input = {
+      ppl: 'source = test | stats count()',
+      dataSourceId: 'test-source',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should add simple count aggregation when no time field is provided', async () => {
+    const input = {
+      ppl: 'source = test',
+      dataSourceId: 'test-source',
+    };
+
+    const expected = {
+      ppl: 'source = test | stats count()',
+      dataSourceId: 'test-source',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+  });
+
+  it('should add time-based aggregation when time field is provided', async () => {
+    const input = {
+      ppl: 'source = test',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    // Mock successful search response
+    const mockResponse = {
+      rawResponse: {
+        total: 1,
+        jsonData: [
+          {
+            min: '2023-01-01',
+            max: '2023-12-31',
+          },
+        ],
+      },
+    };
+
+    mockSearchClient.search.mockReturnValue({
+      toPromise: () => Promise.resolve(mockResponse),
+    });
+    mockSearchClient.aggs.calculateAutoTimeExpression.mockReturnValue('1d');
+
+    const expected = {
+      ppl: 'source = test | stats count() by span(timestamp, 1d)',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+    expect(mockSearchClient.search).toHaveBeenCalledWith(
+      {
+        params: {
+          body: {
+            query: 'source = test | stats min(timestamp) as min, max(timestamp) as max',
+          },
+        },
+        dataSourceId: 'test-source',
+      },
+      { strategy: 'pplraw' }
+    );
+  });
+
+  it('should handle empty search results for time-based queries', async () => {
+    const input = {
+      ppl: 'source = test',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    // Mock empty search response
+    const mockResponse = {
+      rawResponse: {
+        total: 0,
+        jsonData: [],
+      },
+    };
+
+    mockSearchClient.search.mockReturnValue({
+      toPromise: () => Promise.resolve(mockResponse),
+    });
+
+    const expected = {
+      ppl: 'source = test | stats count()',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle search errors', async () => {
+    const input = {
+      ppl: 'source = test',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    mockSearchClient.search.mockReturnValue({
+      toPromise: () => Promise.reject(new Error('Search failed')),
+    });
+
+    const expected = {
+      ...input,
+      ppl: 'source = test | stats count()',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+  });
+
+  describe('isPPLHasAggregation', () => {
+    it('should detect stats command with various spacing', () => {
+      const testCases = [
+        'source = test | stats count()',
+        'source = test |stats count()',
+        'source = test| stats count()',
+        'source = test|stats count()',
+      ];
+
+      testCases.forEach((ppl) => {
+        expect(pplAutoSuggestTask.isPPLHasAggregation(ppl)).toBeTruthy();
+      });
+    });
+
+    it('should return false for queries without stats', () => {
+      const ppl = 'source = test | where count > 0';
+      expect(pplAutoSuggestTask.isPPLHasAggregation(ppl)).toBeFalsy();
+    });
+  });
+});

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
@@ -131,6 +131,30 @@ describe('PPLAutoSuggestTask', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should handle null search results for time-based queries', async () => {
+    const input = {
+      ppl: 'source = test',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    // Mock null search response
+    const mockResponse = null;
+
+    mockSearchClient.search.mockReturnValue({
+      toPromise: () => Promise.resolve(mockResponse),
+    });
+
+    const expected = {
+      ppl: 'source = test | stats count()',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+  });
+
   it('should handle search errors', async () => {
     const input = {
       ppl: 'source = test',

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
@@ -4,10 +4,10 @@
  */
 
 import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
-import { PPLAutoSuggestTask } from './ppl_aggs_auto_suggest_task';
+import { PPLAggsAutoSuggestTask } from './ppl_aggs_auto_suggest_task';
 
 describe('PPLAutoSuggestTask', () => {
-  let pplAutoSuggestTask: PPLAutoSuggestTask;
+  let pplAutoSuggestTask: PPLAggsAutoSuggestTask;
   let mockSearchClient: DataPublicPluginStart['search'];
 
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe('PPLAutoSuggestTask', () => {
         calculateAutoTimeExpression: jest.fn(),
       },
     };
-    pplAutoSuggestTask = new PPLAutoSuggestTask(mockSearchClient);
+    pplAutoSuggestTask = new PPLAggsAutoSuggestTask(mockSearchClient);
   });
 
   it('should return original input if PPL is empty', async () => {

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Task } from './task';
+import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
+
+interface Input {
+  ppl: string;
+  dataSourceId: string | undefined;
+  timeFiledName?: string;
+}
+
+export class PPLAutoSuggestTask extends Task<Input, Input> {
+  searchClient: DataPublicPluginStart['search'];
+
+  constructor(searchClient: DataPublicPluginStart['search']) {
+    super();
+    this.searchClient = searchClient;
+  }
+
+  async execute<T extends Input>(v: T) {
+    let ppl = v.ppl;
+
+    if (ppl) {
+      const isPPLHasAgg = this.isPPLHasAggregation(ppl);
+      // if no aggregation, will try auto suggest one
+      if (!isPPLHasAgg) {
+        if (v.timeFiledName) {
+          const dateRangePPL = `${ppl} | stats min(${v.timeFiledName}) as min, max(${v.timeFiledName}) as max`;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let res: any;
+          try {
+            res = await this.searchClient
+              .search(
+                { params: { body: { query: dateRangePPL } }, dataSourceId: v.dataSourceId },
+                { strategy: 'pplraw' }
+              )
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .toPromise<any>();
+
+            if (res.rawResponse.total === 0) {
+              ppl = `${ppl} | stats count()`;
+            } else {
+              // get min and max and calculate proper interval by range
+              const min = res.rawResponse.jsonData[0].min;
+              const max = res.rawResponse.jsonData[0].max;
+              const interval =
+                this.searchClient.aggs.calculateAutoTimeExpression({ from: min, to: max }) || '1d';
+
+              ppl = `${ppl} | stats count() by span(${v.timeFiledName}, ${interval})`;
+            }
+          } catch (e) {
+            ppl = `${ppl} | stats count()`;
+          }
+        } else {
+          ppl = `${ppl} | stats count()`;
+        }
+
+        // override the original input with suggested ppl
+        return { ...v, ppl };
+      }
+    }
+    // directly return original input
+    return v;
+  }
+
+  private isPPLHasAggregation(ppl: string) {
+    const statsRegex = /\|\s*stats\s+/i;
+    return statsRegex.test(ppl);
+  }
+}

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
@@ -40,7 +40,7 @@ export class PPLAggsAutoSuggestTask extends Task<Input, Input> {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               .toPromise<any>();
 
-            if (res.rawResponse.total === 0) {
+            if (!res || !res.rawResponse || res.rawResponse.total === 0) {
               ppl = `${ppl} | stats count()`;
             } else {
               // get min and max and calculate proper interval by range

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
@@ -12,7 +12,7 @@ interface Input {
   timeFiledName?: string;
 }
 
-export class PPLAutoSuggestTask extends Task<Input, Input> {
+export class PPLAggsAutoSuggestTask extends Task<Input, Input> {
   searchClient: DataPublicPluginStart['search'];
 
   constructor(searchClient: DataPublicPluginStart['search']) {

--- a/public/utils/pipeline/text_to_ppl_task.ts
+++ b/public/utils/pipeline/text_to_ppl_task.ts
@@ -19,6 +19,7 @@ interface Input {
   inputQuestion: string;
   index: string;
   dataSourceId?: string;
+  timeFiledName?: string;
 }
 
 export class Text2PPLTask extends Task<Input, Input & { ppl: string }> {
@@ -37,16 +38,6 @@ export class Text2PPLTask extends Task<Input, Input & { ppl: string }> {
       throw new Error(
         `Error while generating PPL query with input: ${v.inputQuestion}. Please try rephrasing your question.`
       );
-    }
-
-    if (ppl) {
-      const statsRegex = /\|\s*stats\s+/i;
-      const hasStats = statsRegex.test(ppl);
-      if (!hasStats) {
-        throw new Error(
-          `The generated PPL query doesn't seem to contain an aggregation. Ensure your question contains an aggregation (e.g., average, sum, or count) to create a meaningful visualization. Generated PPL: ${ppl}`
-        );
-      }
     }
 
     return { ...v, ppl };


### PR DESCRIPTION
### Description

Add auto aggregation suggest for t2v. It will depends on whether index pattern has time field or not, if it don't have time field, will simply use `count` as aggregation method, otherwise, trying to figure out the best interval for date histogram

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
