### PR TITLE
Fix http request for insights to be triggered only after view insights button is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 - log error body or message instead of the entire error object ([#548](https://github.com/opensearch-project/dashboards-assistant/pull/548))
+- Fix http request for insights to be triggered only after view insights button is clicked ([#520](https://github.com/opensearch-project/dashboards-assistant/pull/520))
 
 ### Infrastructure
 


### PR DESCRIPTION
### Description

Fix the load insights http request' timing. Previously, the request is made instantly after the request for summary, this PR make it only be made after user click "view insights".

### Issues Resolved

https://github.com/user-attachments/assets/27cbc573-f610-4dd1-b3fd-c7fc892d7dae



### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [x] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
