### PR TITLE
Render Icon based on chat bot status (enabled or not)

### DIFF
--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -433,7 +433,7 @@ export const Text2Viz = () => {
             onChange={(e) => setInputQuestion(e.target.value)}
             fullWidth
             compressed
-            prepend={<EuiIcon type={getLogoIcon('gray')} />}
+            prepend={config.chat.enabled ? <></> : <EuiIcon type={getLogoIcon('gray')} />}
             placeholder="Generate visualization with a natural language question."
             onKeyDown={(e) => e.key === 'Enter' && onSubmit()}
             disabled={!selectedSource}


### PR DESCRIPTION
### Description
We need to remove the icon from the form field so it doesn’t conflict with the far-right chat entrypoint. In this change, the icon will only display when chat bot is enabled. 

### Issues Resolved
No Issues are related.

### Check List
- [ ] New functionality includes testing.
- [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
