### PR TITLE
remove fields clause from generated ppl query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - remove redundant error toast([#515](https://github.com/opensearch-project/dashboards-assistant/pull/515))
 - Add auto suggested aggregation for text2Viz ([#514](https://github.com/opensearch-project/dashboards-assistant/pull/514))
 - Remove experimental badge for natural language vis ([#516](https://github.com/opensearch-project/dashboards-assistant/pull/516))
+- t2viz remove fields clause from generated PPL query ([#525](https://github.com/opensearch-project/dashboards-assistant/pull/525))
 
 ### Bug Fixes
 

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
@@ -56,6 +56,31 @@ describe('PPLAutoSuggestTask', () => {
     expect(result).toEqual(expected);
   });
 
+  it('should remove fields command when adding aggregation without time field', async () => {
+    const input = {
+      ppl: 'source = test | fields field1, field2',
+      dataSourceId: 'test-source',
+    };
+
+    const expected = {
+      ppl: 'source = test | stats count()',
+      dataSourceId: 'test-source',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+  });
+
+  it('should keep fields command when PPL already has aggregation', async () => {
+    const input = {
+      ppl: 'source = test | fields field1, field2 | stats count()',
+      dataSourceId: 'test-source',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(input);
+  });
+
   it('should add time-based aggregation when time field is provided', async () => {
     const input = {
       ppl: 'source = test',
@@ -100,6 +125,89 @@ describe('PPLAutoSuggestTask', () => {
       },
       { strategy: 'pplraw' }
     );
+  });
+
+  it('should remove fields command when adding time-based aggregation', async () => {
+    const input = {
+      ppl: 'source = test | fields field1, field2',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    const mockResponse = {
+      rawResponse: {
+        total: 1,
+        jsonData: [
+          {
+            min: '2023-01-01',
+            max: '2023-12-31',
+          },
+        ],
+      },
+    };
+
+    mockSearchClient.search.mockReturnValue({
+      toPromise: () => Promise.resolve(mockResponse),
+    });
+    mockSearchClient.aggs.calculateAutoTimeExpression.mockReturnValue('1d');
+
+    const expected = {
+      ppl: 'source = test | stats count() by span(timestamp, 1d)',
+      dataSourceId: 'test-source',
+      timeFiledName: 'timestamp',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle multiple pipe commands including fields', async () => {
+    const input = {
+      ppl: 'source = test | where count > 0 | fields field1, field2',
+      dataSourceId: 'test-source',
+    };
+
+    const expected = {
+      ppl: 'source = test | where count > 0 | stats count()',
+      dataSourceId: 'test-source',
+    };
+
+    const result = await pplAutoSuggestTask.execute(input);
+    expect(result).toEqual(expected);
+  });
+
+  it('should handle multiple fields commands', async () => {
+    expect(
+      await pplAutoSuggestTask.execute({
+        ppl: 'source = test | fields field1, field2 | where field1 > 0 | fields field2',
+        dataSourceId: 'test-source',
+      })
+    ).toEqual({
+      ppl: 'source = test| where field1 > 0 | stats count()',
+      dataSourceId: 'test-source',
+    });
+
+    expect(
+      await pplAutoSuggestTask.execute({
+        ppl:
+          'source = test | fields field1, field2 | where field1 > 0 | fields field2 | where field2 > 0',
+        dataSourceId: 'test-source',
+      })
+    ).toEqual({
+      ppl: 'source = test| where field1 > 0| where field2 > 0 | stats count()',
+      dataSourceId: 'test-source',
+    });
+
+    expect(
+      await pplAutoSuggestTask.execute({
+        ppl:
+          'source = test | fields field1, field2 \n| where field1 > 0 \n| fields field2 \n| where field2 > 0',
+        dataSourceId: 'test-source',
+      })
+    ).toEqual({
+      ppl: 'source = test| where field1 > 0| where field2 > 0 | stats count()',
+      dataSourceId: 'test-source',
+    });
   });
 
   it('should handle empty search results for time-based queries', async () => {
@@ -175,7 +283,7 @@ describe('PPLAutoSuggestTask', () => {
     expect(result).toEqual(expected);
   });
 
-  describe('isPPLHasAggregation', () => {
+  describe('pplHasAggregation', () => {
     it('should detect stats command with various spacing', () => {
       const testCases = [
         'source = test | stats count()',
@@ -185,13 +293,43 @@ describe('PPLAutoSuggestTask', () => {
       ];
 
       testCases.forEach((ppl) => {
-        expect(pplAutoSuggestTask.isPPLHasAggregation(ppl)).toBeTruthy();
+        expect(pplAutoSuggestTask.pplHasAggregation(ppl)).toBeTruthy();
       });
     });
 
     it('should return false for queries without stats', () => {
       const ppl = 'source = test | where count > 0';
-      expect(pplAutoSuggestTask.isPPLHasAggregation(ppl)).toBeFalsy();
+      expect(pplAutoSuggestTask.pplHasAggregation(ppl)).toBeFalsy();
+    });
+  });
+
+  describe('pplHasFields', () => {
+    it('should handle fields command with various patterns', async () => {
+      const inputs = [
+        'source = test |fields field1, field2',
+        'source = test | fields field1',
+        'source = test |  fields field1, field2',
+        'source = test|  fields field1, field2',
+        'source = test  |fields field1, field2',
+        'source = test  |fields field1, field2|where field1 < 0',
+        'source = test  |fields field1, field2|where field1 < 0',
+        'source = test  |fields field1, field2|where field1 < 0|fields field2',
+        'source = test  |fields field1, field2  | where field1 < 0 |  fields field2 ',
+        'source = test  |fields field1, field2  \n| where field1 < 0 \n|  fields field2 ',
+      ];
+
+      for (const input of inputs) {
+        const regex = new RegExp(pplAutoSuggestTask.fieldsRegex);
+        const result = regex.test(input);
+        expect(result).toBe(true);
+      }
+    });
+
+    it('should return false for queries without fields', () => {
+      const ppl = 'source = test | where count > 0';
+      const regex = new RegExp(pplAutoSuggestTask.fieldsRegex);
+      const result = regex.test(ppl);
+      expect(result).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### Description
remove fields clause from generated ppl query which causes ppl to fail after adding aggregation

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
