### PR TITLE
Fix vertical alignment of the insights popover title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 - remove experimental badge for vis-nlp ([#528](https://github.com/opensearch-project/dashboards-assistant/pull/528))
+- Fix vertically alignment of alert insights popover title ([#526](https://github.com/opensearch-project/dashboards-assistant/pull/526))
 
 ### Infrastructure
 

--- a/public/components/incontext_insight/generate_popover_body.test.tsx
+++ b/public/components/incontext_insight/generate_popover_body.test.tsx
@@ -122,14 +122,15 @@ describe('GeneratePopoverBody', () => {
     );
 
     // 1. Auto generate summary
-    // title is assistant icon + 'Summary'
-    expect(getByLabelText('alert-assistant')).toBeInTheDocument();
-    expect(getByText('Summary')).toBeInTheDocument();
     // content is loading
     expect(getByLabelText('loading_content')).toBeInTheDocument();
 
     // Wait for loading to complete and summary to render
     await waitFor(() => {
+      // title is assistant icon + 'Summary'
+      expect(getByLabelText('alert-assistant')).toBeInTheDocument();
+      expect(getByText('Summary')).toBeInTheDocument();
+
       expect(getByText('Generated summary content')).toBeInTheDocument();
     });
     // loading content disappeared
@@ -202,14 +203,15 @@ describe('GeneratePopoverBody', () => {
       />
     );
 
-    // title is assistant icon + 'Summary'
-    expect(getByLabelText('alert-assistant')).toBeInTheDocument();
-    expect(getByText('Summary')).toBeInTheDocument();
     // content is loading
     expect(getByLabelText('loading_content')).toBeInTheDocument();
 
     // Wait for loading to complete and summary to render
     await waitFor(() => {
+      // title is assistant icon + 'Summary'
+      expect(getByLabelText('alert-assistant')).toBeInTheDocument();
+      expect(getByText('Summary')).toBeInTheDocument();
+
       expect(getByText('Generated summary content')).toBeInTheDocument();
     });
     // loading content disappeared

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -19,6 +19,7 @@ import {
   EuiTitle,
   EuiButton,
   EuiButtonEmpty,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import { useEffectOnce } from 'react-use';
 import { METRIC_TYPE } from '@osd/analytics';
@@ -260,8 +261,10 @@ export const GeneratePopoverBody: React.FC<{
     }
   };
 
+  const getContent = () => (showInsight && insightAvailable ? insight : summary);
+
   const renderContent = () => {
-    const content = showInsight && insightAvailable ? insight : summary;
+    const content = getContent();
     return content ? (
       <>
         <EuiPanel paddingSize="s" hasBorder hasShadow={false}>
@@ -278,27 +281,32 @@ export const GeneratePopoverBody: React.FC<{
   };
 
   const renderInnerTitle = () => {
+    const content = getContent();
     return (
       <EuiPopoverTitle className="incontextInsightGeneratePopoverTitle" paddingSize="l">
         <EuiFlexGroup gutterSize="xs" alignItems="center">
           <EuiFlexItem grow={false}>
-            {showInsight ? (
-              <EuiIcon
-                aria-label="back-to-summary"
-                size="m"
-                onClick={() => {
-                  setShowInsight(false);
-                }}
-                type="arrowLeft"
-                color="ghost"
-              />
+            {content ? (
+              showInsight ? (
+                <EuiIcon
+                  aria-label="back-to-summary"
+                  size="m"
+                  onClick={() => {
+                    setShowInsight(false);
+                  }}
+                  type="arrowLeft"
+                  color="ghost"
+                />
+              ) : (
+                <EuiIcon
+                  aria-label="alert-assistant"
+                  color="hollow"
+                  size="m"
+                  type={getLogoIcon('gradient', shiny_sparkle)}
+                />
+              )
             ) : (
-              <EuiIcon
-                aria-label="alert-assistant"
-                color="hollow"
-                size="m"
-                type={getLogoIcon('gradient', shiny_sparkle)}
-              />
+              <EuiLoadingSpinner />
             )}
           </EuiFlexItem>
           <EuiFlexItem>

--- a/public/components/incontext_insight/index.scss
+++ b/public/components/incontext_insight/index.scss
@@ -105,20 +105,20 @@
   max-width: 486px;
   min-width: 486px;
   width: 100%;
+}
+
+.incontextInsightGeneratePopoverTitle {
+  margin-bottom: 0 !important;
+  border: none;
+  display: flex;
 
   .euiTitle {
     color: $euiColorGhost;
   }
-}
 
-.incontextInsightGeneratePopoverTitle {
-  // TODO: Remove this one paddingSize is fixed
-  padding: 0 !important;
-  padding-left: 5px !important;
-  margin-bottom: 0 !important;
-  min-height: 30px;
-  max-height: 30px;
-  border: none;
+  .euiFlexGroup {
+    gap: $euiSizeXS;
+  }
 }
 
 .incontextInsightGeneratePopoverFooter {


### PR DESCRIPTION
### Description
Change the title to be a flex box so that the items stretch to fill the container's height so make sure the popover title aligned center vertically regardless of font size and line height.

<img width="408" alt="Screenshot 2025-04-01 at 10 36 20" src="https://github.com/user-attachments/assets/b6486792-fa42-4b91-8630-3c6b8cc0a2b0" />
<img width="431" alt="Screenshot 2025-04-01 at 10 36 28" src="https://github.com/user-attachments/assets/54615afe-fcf0-4e9f-b984-964c1e0a4647" />

Also, display a spinning icon when loading the content.

<img width="532" alt="Screenshot 2025-04-01 at 13 50 27" src="https://github.com/user-attachments/assets/35985710-c5ad-4118-a341-6bdabe6f3717" />


### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
