### PR TITLE
[t2viz] Prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## Unreleased
 
 ### Features
+- Prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result ([#532](https://github.com/opensearch-project/dashboards-assistant/pull/532))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## Unreleased
 
 ### Features
-- Prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result ([#532](https://github.com/opensearch-project/dashboards-assistant/pull/532))
 
 ### Enhancements
 

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -38,6 +38,7 @@ export const ActionContextMenu = (props: Props) => {
   const uiActions = getUiActions();
   const actionsRef = useRef(uiActions.getTriggerActions(AI_ASSISTANT_QUERY_EDITOR_TRIGGER));
   const [open, setOpen] = useState(false);
+  const { search } = props.data;
   const [actionContext, setActionContext] = useState({
     datasetId: props.data.query.queryString.getQuery().dataset?.id ?? '',
     datasetType: props.data.query.queryString.getQuery().dataset?.type ?? '',
@@ -47,6 +48,7 @@ export const ActionContextMenu = (props: Props) => {
   const isQuerySummaryCollapsed = useObservable(props.isQuerySummaryCollapsed$, false);
   const isSummaryAgentAvailable = useObservable(props.isSummaryAgentAvailable$, false);
   const shouldShowSummarizationAction = resultSummaryEnabled && isSummaryAgentAvailable;
+  const [showGenerateVisualization, setShowGenerateVisualization] = useState(false);
 
   useEffect(() => {
     if (!resultSummaryEnabled) return;
@@ -130,7 +132,14 @@ export const ActionContextMenu = (props: Props) => {
             aria-label="OpenSearch assistant trigger button"
             size="xs"
             iconType="arrowDown"
-            onClick={() => setOpen(!open)}
+            onClick={() => {
+              if (search.df.df$.hasError || search.df.df$.value?.size === 0) {
+                setShowGenerateVisualization(false);
+              } else {
+                setShowGenerateVisualization(true);
+              }
+              setOpen(!open);
+            }}
             iconSide="right"
             flush="both"
             isDisabled={actionDisabled}
@@ -148,7 +157,15 @@ export const ActionContextMenu = (props: Props) => {
       anchorPosition="downRight"
       closePopover={() => setOpen(false)}
     >
-      <EuiContextMenu size="s" initialPanelId={'mainMenu'} panels={panels.value} />
+      {showGenerateVisualization ? (
+        <EuiContextMenu size="s" initialPanelId={'mainMenu'} panels={panels.value} />
+      ) : (
+        <EuiToolTip content="This button be disabled because of No Results/Error.">
+          <div style={{ pointerEvents: 'none' }}>
+            <EuiContextMenu size="s" initialPanelId={'mainMenu'} panels={panels.value} />
+          </div>
+        </EuiToolTip>
+      )}
       {shouldShowSummarizationAction && (
         <EuiPopoverFooter paddingSize="s">
           <EuiSwitch

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -160,7 +160,11 @@ export const ActionContextMenu = (props: Props) => {
       {showGenerateVisualization ? (
         <EuiContextMenu size="s" initialPanelId={'mainMenu'} panels={panels.value} />
       ) : (
-        <EuiToolTip content="This button be disabled because of No Results/Error.">
+        <EuiToolTip
+          content={i18n.translate('queryEnhancements.queryAssist.generate.visualization.label', {
+            defaultMessage: `This button be disabled because of No Results/Error.`,
+          })}
+        >
           <div style={{ pointerEvents: 'none' }}>
             <EuiContextMenu size="s" initialPanelId={'mainMenu'} panels={panels.value} />
           </div>

--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -12,6 +12,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 - Render Icon based on the chat status ([#523](https://github.com/opensearch-project/dashboards-assistant/pull/523))
 - Add scroll load conversations ([#530](https://github.com/opensearch-project/dashboards-assistant/pull/530))
 - Refactor InContext style, add white logo and remove outdated code ([#529](https://github.com/opensearch-project/dashboards-assistant/pull/529))
+- Prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result ([#532](https://github.com/opensearch-project/dashboards-assistant/pull/532))
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Description
[t2viz] Prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result

### Issues Resolved
[List any issues this PR will resolve]


https://github.com/user-attachments/assets/2916aa08-bbed-4cd3-8094-05b38db620e7







### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
