### PR TITLE
Add metrics for conversation related API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## Unreleased
 
 ### Features
+- Add metrics for conversation related API calls ([#535](https://github.com/opensearch-project/dashboards-assistant/pull/535))
 
 ### Enhancements
 

--- a/common/constants/metrics.ts
+++ b/common/constants/metrics.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const CHAT_APP_NAME = 'chat';
+export const CHAT_METRIC_SEND_MESSAGE_SUCCESS = 'sendMessage_api_call_success';
+export const CHAT_METRIC_SEND_MESSAGE_FAILURE = 'sendMessage_api_call_failure';
+export const CHAT_METRIC_GET_CONVERSATION_SUCCESS = 'getConversation_api_call_success';
+export const CHAT_METRIC_GET_CONVERSATION_FAILURE = 'getConversation_api_call_failure';
+export const CHAT_METRIC_LIST_CONVERSATIONS_SUCCESS = 'listConversations_api_call_success';
+export const CHAT_METRIC_LIST_CONVERSATIONS_FAILURE = 'listConversations_api_call_failure';

--- a/public/hooks/use_chat_actions.test.tsx
+++ b/public/hooks/use_chat_actions.test.tsx
@@ -15,14 +15,6 @@ import { ASSISTANT_API } from '../../common/constants/llm';
 import { IMessage } from 'common/types/chat_saved_object_attributes';
 import { DataSourceServiceMock } from '../services/data_source_service.mock';
 
-jest.mock('../services/conversations_service', () => {
-  return {
-    ConversationsService: jest.fn().mockImplementation(() => {
-      return { reload: jest.fn() };
-    }),
-  };
-});
-
 jest.mock('../services/conversation_load_service', () => {
   return {
     ConversationLoadService: jest.fn().mockImplementation(() => {

--- a/public/hooks/use_chat_actions.tsx
+++ b/public/hooks/use_chat_actions.tsx
@@ -28,15 +28,11 @@ export const useChatActions = (): AssistantActions => {
     abortControllerRef = abortController;
     chatStateDispatch({ type: 'send', payload: input });
     try {
-      const response = await core.services.http.post<SendResponse>(ASSISTANT_API.SEND_MESSAGE, {
-        // do not send abort signal to http client to allow LLM call run in background
-        body: JSON.stringify({
-          conversationId: chatContext.conversationId,
-          ...(!chatContext.conversationId && { messages: chatState.messages }), // include all previous messages for new chats
-          input,
-        }),
-        query: core.services.dataSource.getDataSourceQuery(),
-      });
+      const response = await core.services.conversations.sendMessage(
+        input,
+        chatState.messages,
+        chatContext.conversationId
+      );
       if (abortController.signal.aborted) return;
       // Refresh history list after new conversation created if new conversation saved and history list page visible
       if (

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -235,8 +235,16 @@ export class AssistantPlugin
         ...coreStart,
         setupDeps,
         startDeps,
-        conversationLoad: new ConversationLoadService(coreStart.http, this.dataSourceService),
-        conversations: new ConversationsService(coreStart.http, this.dataSourceService),
+        conversationLoad: new ConversationLoadService(
+          coreStart.http,
+          this.dataSourceService,
+          setupDeps.usageCollection
+        ),
+        conversations: new ConversationsService(
+          coreStart.http,
+          this.dataSourceService,
+          setupDeps.usageCollection
+        ),
         dataSource: this.dataSourceService,
       });
       const account = await getAccount();

--- a/public/services/conversations_service.ts
+++ b/public/services/conversations_service.ts
@@ -5,9 +5,22 @@
 
 import { BehaviorSubject } from 'rxjs';
 import { HttpFetchQuery, HttpStart, SavedObjectsFindOptions } from '../../../../src/core/public';
-import { IConversationFindResponse } from '../../common/types/chat_saved_object_attributes';
+import {
+  IConversationFindResponse,
+  IMessage,
+  SendResponse,
+} from '../../common/types/chat_saved_object_attributes';
 import { ASSISTANT_API } from '../../common/constants/llm';
 import { DataSourceService } from './data_source_service';
+import { UsageCollectionSetup } from '../../../../src/plugins/usage_collection/public/plugin';
+import { reportMetric } from '../utils/report_metric';
+import {
+  CHAT_APP_NAME,
+  CHAT_METRIC_LIST_CONVERSATIONS_FAILURE,
+  CHAT_METRIC_LIST_CONVERSATIONS_SUCCESS,
+  CHAT_METRIC_SEND_MESSAGE_FAILURE,
+  CHAT_METRIC_SEND_MESSAGE_SUCCESS,
+} from '../../common/constants/metrics';
 
 export class ConversationsService {
   conversations$: BehaviorSubject<IConversationFindResponse | null> = new BehaviorSubject<IConversationFindResponse | null>(
@@ -22,7 +35,11 @@ export class ConversationsService {
   >;
   abortController?: AbortController;
 
-  constructor(private _http: HttpStart, private _dataSource: DataSourceService) {}
+  constructor(
+    private _http: HttpStart,
+    private _dataSource: DataSourceService,
+    private usageCollection?: UsageCollectionSetup
+  ) {}
 
   public get options() {
     return this._options;
@@ -49,13 +66,34 @@ export class ConversationsService {
         })
       );
       this.status$.next('idle');
+      reportMetric(this.usageCollection, CHAT_APP_NAME, CHAT_METRIC_LIST_CONVERSATIONS_SUCCESS);
     } catch (error) {
       this.conversations$.next(null);
       this.status$.next({ error });
+      reportMetric(this.usageCollection, CHAT_APP_NAME, CHAT_METRIC_LIST_CONVERSATIONS_FAILURE);
     }
   };
 
   reload = () => {
     this.load(this._options);
+  };
+
+  sendMessage = async (input: IMessage, messages: IMessage[], conversationId?: string) => {
+    try {
+      const response = await this._http.post<SendResponse>(ASSISTANT_API.SEND_MESSAGE, {
+        // do not send abort signal to http client to allow LLM call run in background
+        body: JSON.stringify({
+          conversationId,
+          ...(!conversationId && { messages }), // include all previous messages for new chats
+          input,
+        }),
+        query: this._dataSource.getDataSourceQuery(),
+      });
+      reportMetric(this.usageCollection, CHAT_APP_NAME, CHAT_METRIC_SEND_MESSAGE_SUCCESS);
+      return response;
+    } catch (error) {
+      reportMetric(this.usageCollection, CHAT_APP_NAME, CHAT_METRIC_SEND_MESSAGE_FAILURE);
+      throw error;
+    }
   };
 }


### PR DESCRIPTION
### Description
This PR adds metrics for the sendMessage, getConversation, getConversations API call.

### Issues Resolved
https://github.com/opensearch-project/dashboards-assistant/issues/534

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
