### PR TITLE
style single metric in text2vis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Enhancements
 
+- Style single metric in text2vis ([#539](https://github.com/opensearch-project/dashboards-assistant/pull/539))
+
 ### Bug Fixes
 
 ### Infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Enhancements
 
-- Style single metric in text2vis ([#539](https://github.com/opensearch-project/dashboards-assistant/pull/539))
-
 ### Bug Fixes
 
 ### Infrastructure

--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -12,9 +12,13 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 - Render Icon based on the chat status ([#523](https://github.com/opensearch-project/dashboards-assistant/pull/523))
 - Add scroll load conversations ([#530](https://github.com/opensearch-project/dashboards-assistant/pull/530))
 - Refactor InContext style, add white logo and remove outdated code ([#529](https://github.com/opensearch-project/dashboards-assistant/pull/529))
+<<<<<<< HEAD
 - Change chatbot entry point to a single button ([#540](https://github.com/opensearch-project/dashboards-assistant/pull/540))
 - Support streaming output([#493](https://github.com/opensearch-project/dashboards-assistant/pull/493))
 - Update event names for t2v and feedback ([#543](https://github.com/opensearch-project/dashboards-assistant/pull/543))
+=======
+- Style single metric in text2vis ([#539](https://github.com/opensearch-project/dashboards-assistant/pull/539))
+>>>>>>> 954f106 (avoid using any)
 
 ### Bug Fixes
 

--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -12,13 +12,10 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 - Render Icon based on the chat status ([#523](https://github.com/opensearch-project/dashboards-assistant/pull/523))
 - Add scroll load conversations ([#530](https://github.com/opensearch-project/dashboards-assistant/pull/530))
 - Refactor InContext style, add white logo and remove outdated code ([#529](https://github.com/opensearch-project/dashboards-assistant/pull/529))
-<<<<<<< HEAD
 - Change chatbot entry point to a single button ([#540](https://github.com/opensearch-project/dashboards-assistant/pull/540))
 - Support streaming output([#493](https://github.com/opensearch-project/dashboards-assistant/pull/493))
 - Update event names for t2v and feedback ([#543](https://github.com/opensearch-project/dashboards-assistant/pull/543))
-=======
 - Style single metric in text2vis ([#539](https://github.com/opensearch-project/dashboards-assistant/pull/539))
->>>>>>> 954f106 (avoid using any)
 
 ### Bug Fixes
 

--- a/server/utils/style_single_metric.test.ts
+++ b/server/utils/style_single_metric.test.ts
@@ -6,16 +6,15 @@
 import { checkSingleMetric, addTitleTextLayer } from './style_single_metric';
 
 describe('checkSingleMetric', () => {
-  it('should return true when there is exactly 1 metric and 0 dimensions', () => {
-    const input = `
-      Number of metrics: [avg(sales)] <number of metrics {1}>
-      Number of dimensions: [] <number of dimension {0}>
-    `;
+  it('should return true when the input sample data only have one value', () => {
+    const input = '"[{\\"count()\\":13059}]"';
     expect(checkSingleMetric(input)).toBe(true);
   });
 
   it('should return false when the format is invalid', () => {
-    const input = `Invalid text`;
+    const input = `
+     "[{\"flight_count\":5,\"DestCountry\":\"AE\"},{\"flight_count\":55,\"DestCountry\":\"AR\"}]"
+    `;
     expect(checkSingleMetric(input)).toBe(false);
   });
 });

--- a/server/utils/style_single_metric.test.ts
+++ b/server/utils/style_single_metric.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { checkSingleMetric, addTitleTextLayer } from './style_single_metric';
+
+describe('checkSingleMetric', () => {
+  it('should return true when there is exactly 1 metric and 0 dimensions', () => {
+    const input = `
+      Number of metrics: [avg(sales)] <number of metrics {1}>
+      Number of dimensions: [] <number of dimension {0}>
+    `;
+    expect(checkSingleMetric(input)).toBe(true);
+  });
+
+  it('should return false when the format is invalid', () => {
+    const input = `Invalid text`;
+    expect(checkSingleMetric(input)).toBe(false);
+  });
+});
+
+describe('addTitleTextLayer', () => {
+  it('should add a title text layer when layer already exists', () => {
+    const input = {
+      title: 'test',
+      layer: [
+        {
+          mark: { type: 'bar' },
+          encoding: { x: { field: 'count' } },
+        },
+      ],
+    };
+
+    const result = addTitleTextLayer(input);
+    expect(result.layer).toHaveLength(2);
+    expect(result.layer[1].encoding.text.value).toBe('test');
+  });
+
+  it('should create a layer array and add title when layer does not exist', () => {
+    const input = {
+      title: 'test',
+      mark: { type: 'text', fontSize: 14 },
+      encoding: { text: { field: 'count' } },
+    };
+
+    const result = addTitleTextLayer(input);
+    expect(result.layer).toHaveLength(2);
+    expect(result.layer[1].mark.type).toBe('text');
+    expect(result.layer[1].encoding.text.value).toBe('test');
+  });
+
+  it('should return the original object if no title', () => {
+    const input = {
+      mark: { type: 'line' },
+      encoding: { x: { field: 'date' }, y: { field: 'views' } },
+    };
+
+    const result = addTitleTextLayer(input);
+    expect(result).toEqual(input);
+  });
+});

--- a/server/utils/style_single_metric.ts
+++ b/server/utils/style_single_metric.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export function addTitleTextLayer(json: any) {
+interface VegaLiteSpec {
+  title?: string;
+  mark?: unknown;
+  encoding?: unknown;
+  layer?: object[];
+}
+
+export function addTitleTextLayer(json: VegaLiteSpec) {
   if (!json.title) return json;
 
   const titleTextLayer = {
@@ -38,12 +45,12 @@ export function addTitleTextLayer(json: any) {
       ],
     };
   }
-  layeredSpec.layer.push(titleTextLayer);
+  layeredSpec.layer?.push(titleTextLayer);
 
   return layeredSpec;
 }
 
-export function checkSingleMetric(textContent: String) {
+export function checkSingleMetric(textContent: string) {
   const metricsMatch = textContent.match(
     /Number of metrics:\s*\[[^\]]*\]\s*<number of metrics\s*\{(\d+)\}>/
   );

--- a/server/utils/style_single_metric.ts
+++ b/server/utils/style_single_metric.ts
@@ -10,7 +10,7 @@ export function addTitleTextLayer(json: any) {
     mark: {
       type: 'text',
       align: 'center',
-      dy: 40,
+      dy: 50,
       fontSize: 16,
       fontWeight: 'bold',
     },
@@ -30,7 +30,7 @@ export function addTitleTextLayer(json: any) {
         {
           mark: {
             type: 'text',
-            fontSize: 50,
+            fontSize: 80,
             fontWeight: 'bold',
           },
           encoding,

--- a/server/utils/style_single_metric.ts
+++ b/server/utils/style_single_metric.ts
@@ -50,16 +50,10 @@ export function addTitleTextLayer(json: VegaLiteSpec) {
   return layeredSpec;
 }
 
-export function checkSingleMetric(textContent: string) {
-  const metricsMatch = textContent.match(
-    /Number of metrics:\s*\[[^\]]*\]\s*<number of metrics\s*\{(\d+)\}>/
-  );
-  const dimensionsMatch = textContent.match(
-    /Number of dimensions:\s*\[[^\]]*\]\s*<number of dimension\s*\{(\d+)\}>/
-  );
+// the sample data format is like : "[{\"flight_count\":2033,\"dayOfWeek\":0}]"
+// will check if the string only contains one single key-value pair
 
-  const metricsCount = metricsMatch ? parseInt(metricsMatch[1], 10) : 0;
-  const dimensionsCount = dimensionsMatch ? parseInt(dimensionsMatch[1], 10) : 0;
-
-  return metricsCount === 1 && dimensionsCount === 0;
+export function checkSingleMetric(sampleData: string): boolean {
+  const regex = /^"\[\{\\?"[^"]+\\?":[^,}]+\}\]"$/;
+  return regex.test(sampleData);
 }

--- a/server/utils/style_single_metric.ts
+++ b/server/utils/style_single_metric.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function addTitleTextLayer(json: any) {
+  if (!json.title) return json;
+
+  const titleTextLayer = {
+    mark: {
+      type: 'text',
+      align: 'center',
+      dy: 40,
+      fontSize: 16,
+      fontWeight: 'bold',
+    },
+    encoding: {
+      text: {
+        value: json.title,
+      },
+    },
+  };
+
+  let layeredSpec = { ...json };
+  if (!json.layer) {
+    const { mark, encoding, ...rest } = json;
+    layeredSpec = {
+      ...rest,
+      layer: [
+        {
+          mark: {
+            type: 'text',
+            fontSize: 50,
+            fontWeight: 'bold',
+          },
+          encoding,
+        },
+      ],
+    };
+  }
+  layeredSpec.layer.push(titleTextLayer);
+
+  return layeredSpec;
+}
+
+export function checkSingleMetric(textContent: String) {
+  const metricsMatch = textContent.match(
+    /Number of metrics:\s*\[[^\]]*\]\s*<number of metrics\s*\{(\d+)\}>/
+  );
+  const dimensionsMatch = textContent.match(
+    /Number of dimensions:\s*\[[^\]]*\]\s*<number of dimension\s*\{(\d+)\}>/
+  );
+
+  const metricsCount = metricsMatch ? parseInt(metricsMatch[1], 10) : 0;
+  const dimensionsCount = dimensionsMatch ? parseInt(dimensionsMatch[1], 10) : 0;
+
+  return metricsCount === 1 && dimensionsCount === 0;
+}


### PR DESCRIPTION
### Description
This pr styles the single metric by adding a text description layer

### Issues Resolved
before:
<img width="800" alt="截屏2025-04-14 11 26 45" src="https://github.com/user-attachments/assets/80ddba0c-0831-4171-9303-6b2b0fc54bfd" />

after:
![截屏2025-04-14 11 27 53](https://github.com/user-attachments/assets/fe7b11da-a434-4361-b335-b96991883105)


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

