### PR TITLE
Change chatbot entry point to a single button

### DIFF
--- a/public/chat_header_button.test.tsx
+++ b/public/chat_header_button.test.tsx
@@ -126,7 +126,8 @@ describe('<HeaderChatButton />', () => {
       ...applicationServiceMock.createStartContract(),
       currentAppId$: new BehaviorSubject(''),
     };
-    render(
+
+    const { getByLabelText } = render(
       <HeaderChatButton
         application={applicationStart}
         messageRenderers={{}}
@@ -138,41 +139,9 @@ describe('<HeaderChatButton />', () => {
 
     act(() => applicationStart.currentAppId$.next('mock_app_id'));
 
-    screen.getByLabelText('chat input').focus();
-    fireEvent.change(screen.getByLabelText('chat input'), {
-      target: { value: 'what indices are in my cluster?' },
-    });
-    expect(screen.getByLabelText('chat input')).toHaveFocus();
-
-    fireEvent.keyPress(screen.getByLabelText('chat input'), {
-      key: 'Enter',
-      code: 'Enter',
-      charCode: 13,
-    });
-
-    // call send message API with new chat
-    await waitFor(() => {
-      expect(coreStartMock.http.post).lastCalledWith(
-        '/api/assistant/send_message',
-        expect.objectContaining({
-          body: JSON.stringify({
-            messages: [],
-            input: {
-              type: 'input',
-              contentType: 'text',
-              content: 'what indices are in my cluster?',
-              context: { appId: 'mock_app_id' },
-            },
-          }),
-        })
-      );
-    });
-
+    fireEvent.click(getByLabelText('toggle chat flyout icon'));
     // chat flyout displayed
     expect(screen.queryByLabelText('chat flyout mock')).toBeInTheDocument();
-    // the input value is cleared after pressing enter
-    expect(screen.getByLabelText('chat input')).toHaveValue('');
-    expect(screen.getByLabelText('chat input')).not.toHaveFocus();
 
     // sidecar show
     const toggleButton = screen.getByLabelText('toggle chat flyout icon');
@@ -181,113 +150,6 @@ describe('<HeaderChatButton />', () => {
     // sidecar hide
     fireEvent.click(toggleButton);
     expect(screen.queryByLabelText('chat flyout mock')).toBeVisible();
-  });
-
-  it('should call send message without active conversation id after input text submitted', async () => {
-    const activeConversationId = 'test-conversation';
-    const assistantActions = {} as AssistantActions;
-    const applicationStart = {
-      ...applicationServiceMock.createStartContract(),
-      currentAppId$: new BehaviorSubject(''),
-    };
-    render(
-      <HeaderChatButton
-        application={applicationStart}
-        messageRenderers={{}}
-        actionExecutors={{}}
-        assistantActions={assistantActions}
-        currentAccount={{ username: 'test_user' }}
-      />
-    );
-
-    act(() => applicationStart.currentAppId$.next('mock_app_id'));
-
-    act(() => {
-      assistantActions.loadChat(activeConversationId);
-    });
-
-    screen.getByLabelText('chat input').focus();
-    fireEvent.change(screen.getByLabelText('chat input'), {
-      target: { value: 'what indices are in my cluster?' },
-    });
-    expect(screen.getByLabelText('chat input')).toHaveFocus();
-    fireEvent.keyPress(screen.getByLabelText('chat input'), {
-      key: 'Enter',
-      code: 'Enter',
-      charCode: 13,
-    });
-
-    await waitFor(() => {
-      expect(coreStartMock.http.post).lastCalledWith(
-        '/api/assistant/send_message',
-        expect.objectContaining({
-          body: expect.not.stringContaining(activeConversationId),
-        })
-      );
-    });
-  });
-
-  it('should focus in chat input when click and press Escape should blur', () => {
-    render(
-      <HeaderChatButton
-        application={applicationServiceMock.createStartContract()}
-        messageRenderers={{}}
-        actionExecutors={{}}
-        assistantActions={{} as AssistantActions}
-        currentAccount={{ username: 'test_user' }}
-      />
-    );
-    screen.getByLabelText('chat input').focus();
-    expect(screen.getByLabelText('chat input')).toHaveFocus();
-    expect(screen.getByTitle('press enter to chat')).toBeInTheDocument();
-
-    fireEvent.keyUp(screen.getByLabelText('chat input'), {
-      key: 'Escape',
-      code: 'Escape',
-      charCode: 27,
-    });
-    expect(screen.getByLabelText('chat input')).not.toHaveFocus();
-    expect(screen.getByTitle('press Ctrl + / to start typing')).toBeInTheDocument();
-  });
-
-  it('should focus on chat input when pressing global shortcut', () => {
-    render(
-      <HeaderChatButton
-        application={applicationServiceMock.createStartContract()}
-        messageRenderers={{}}
-        actionExecutors={{}}
-        assistantActions={{} as AssistantActions}
-        currentAccount={{ username: 'test_user' }}
-      />
-    );
-    expect(screen.getByLabelText('chat input')).not.toHaveFocus();
-    fireEvent.keyDown(document.body, {
-      key: '/',
-      code: 'NumpadDivide',
-      charCode: 111,
-      ctrlKey: true,
-    });
-    expect(screen.getByLabelText('chat input')).toHaveFocus();
-  });
-
-  it('should not focus on chat input when no access and pressing global shortcut', () => {
-    render(
-      <HeaderChatButton
-        application={applicationServiceMock.createStartContract()}
-        messageRenderers={{}}
-        actionExecutors={{}}
-        assistantActions={{} as AssistantActions}
-        currentAccount={{ username: 'test_user' }}
-      />
-    );
-    expect(screen.getByLabelText('chat input')).not.toHaveFocus();
-    fireEvent.keyDown(document.body, {
-      key: '/',
-      code: 'NumpadDivide',
-      charCode: 111,
-      metaKey: true,
-    });
-    expect(screen.getByLabelText('chat input')).not.toHaveFocus();
   });
 
   it('should call sidecar hide and close when button unmount and chat flyout is visible', async () => {
@@ -328,6 +190,6 @@ describe('<HeaderChatButton />', () => {
         inLegacyHeader={false}
       />
     );
-    expect(screen.getByLabelText('toggle chat flyout button icon')).toBeInTheDocument();
+    expect(screen.getByLabelText('toggle chat flyout icon')).toBeInTheDocument();
   });
 });

--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -12,6 +12,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 - Render Icon based on the chat status ([#523](https://github.com/opensearch-project/dashboards-assistant/pull/523))
 - Add scroll load conversations ([#530](https://github.com/opensearch-project/dashboards-assistant/pull/530))
 - Refactor InContext style, add white logo and remove outdated code ([#529](https://github.com/opensearch-project/dashboards-assistant/pull/529))
+- Change chatbot entry point to a single button ([#540](https://github.com/opensearch-project/dashboards-assistant/pull/540))
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Description
This PR is for change chatbot entry point to a single button.

- with new home enabled
![image](https://github.com/user-attachments/assets/719e6edd-8f59-4b7d-9afc-f7f272b34252)
![image](https://github.com/user-attachments/assets/8dc646f7-d0d4-42d6-a72f-2b9942e319b8)

- with new home disabled
![image](https://github.com/user-attachments/assets/e2bece98-5010-44b9-b939-f19b04dacbd0)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
