### PR TITLE
Fix .plugins-ml-memory-meta not found when get conversations

### DIFF
--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -19,6 +19,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 - Fix vertically alignment of alert insights popover title ([#526](https://github.com/opensearch-project/dashboards-assistant/pull/526))
 - Change alert summary icon color to white ([#533](https://github.com/opensearch-project/dashboards-assistant/pull/533))
 - Fix query assistant menu disappear due to upstream method signature change([#541]https://github.com/opensearch-project/dashboards-assistant/pull/541)
+- Fix .plugins-ml-memory-meta not found when get conversations ([#542](https://github.com/opensearch-project/dashboards-assistant/pull/542))
 
 ### Infrastructure
 

--- a/server/routes/chat_routes.ts
+++ b/server/routes/chat_routes.ts
@@ -290,6 +290,14 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
         const getResponse = await storageService.getConversations(request.query);
         return response.ok({ body: getResponse });
       } catch (error) {
+        const errorBody = error?.meta?.body?.error;
+        // Ignore index not found exception for .plugins-ml-memory-meta index
+        if (
+          errorBody?.type === 'index_not_found_exception' &&
+          errorBody?.reason.includes('.plugins-ml-memory-meta')
+        ) {
+          return response.ok({ body: { objects: [], total: 0 } });
+        }
         context.assistant_plugin.logger.error(error);
         return handleError(error, response, context.assistant_plugin.logger);
       }

--- a/server/routes/chat_routes.ts
+++ b/server/routes/chat_routes.ts
@@ -290,12 +290,8 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
         const getResponse = await storageService.getConversations(request.query);
         return response.ok({ body: getResponse });
       } catch (error) {
-        const errorBody = error?.meta?.body?.error;
-        // Ignore index not found exception for .plugins-ml-memory-meta index
-        if (
-          errorBody?.type === 'index_not_found_exception' &&
-          errorBody?.reason.includes('.plugins-ml-memory-meta')
-        ) {
+        // Return empty result for 404 errors
+        if (error?.meta?.statusCode === 404) {
           return response.ok({ body: { objects: [], total: 0 } });
         }
         context.assistant_plugin.logger.error(error);

--- a/server/routes/get_conversations.test.ts
+++ b/server/routes/get_conversations.test.ts
@@ -81,15 +81,10 @@ describe('getConversations route', () => {
     `);
   });
 
-  it('return empty result when ".plugins-ml-memory-meta" index not found', async () => {
+  it('return empty result when getConversations rejected with 404 status code', async () => {
     mockAgentFrameworkStorageService.getConversations.mockRejectedValueOnce({
       meta: {
-        body: {
-          error: {
-            type: 'index_not_found_exception',
-            reason: 'not found [.plugins-ml-memory-meta]',
-          },
-        },
+        statusCode: 404,
       },
     });
 

--- a/server/routes/get_conversations.test.ts
+++ b/server/routes/get_conversations.test.ts
@@ -80,4 +80,29 @@ describe('getConversations route', () => {
       }
     `);
   });
+
+  it('return empty result when ".plugins-ml-memory-meta" index not found', async () => {
+    mockAgentFrameworkStorageService.getConversations.mockRejectedValueOnce({
+      meta: {
+        body: {
+          error: {
+            type: 'index_not_found_exception',
+            reason: 'not found [.plugins-ml-memory-meta]',
+          },
+        },
+      },
+    });
+
+    expect(mockAgentFrameworkStorageService.deleteConversation).not.toHaveBeenCalled();
+    const result = (await getConversationsRequest({
+      perPage: 10,
+      page: 1,
+    })) as ResponseObject;
+    expect(result.source).toMatchInlineSnapshot(`
+      Object {
+        "objects": Array [],
+        "total": 0,
+      }
+    `);
+  });
 });


### PR DESCRIPTION
### Description
This PR is to fix the conversation loading error when `.plugins-ml-memory-meta` index not exists like screenshot below. 
<img width="313" alt="image" src="https://github.com/user-attachments/assets/846d70c1-f1d1-4775-bfcb-3c43324271ce" />
It will return an empty result after this PR merged.


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
