### PR TITLE
Fix: fix empty codecov report in CI

### DIFF
--- a/.github/workflows/unit_test_workflow.yml
+++ b/.github/workflows/unit_test_workflow.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report-linux
-          path: ./OpenSearch-Dashboards/plugins/dashboards-assistant/coverage/
+          path: ./OpenSearch-Dashboards/plugins/dashboards-assistant/coverage/clover.xml
 
   tests-windows-macos:
     name: Run unit tests
@@ -111,4 +111,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./
+          files: ./clover.xml

--- a/.github/workflows/unit_test_workflow.yml
+++ b/.github/workflows/unit_test_workflow.yml
@@ -6,12 +6,12 @@ name: Build and test
 # trigger on every commit push and PR for all branches except pushes for backport branches
 on:
   pull_request:
-    branches: ["**"]
+    branches: ['**']
   push:
-    branches: ["**"]
+    branches: ['**']
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  NODE_OPTIONS: "--max-old-space-size=6144 --dns-result-order=ipv4first"
+  NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
 
 jobs:
   Get-CI-Image-Tag:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-report-linux
-          path: ./OpenSearch-Dashboards/plugins/dashboards-assistant/coverage/clover.xml
+          path: ./OpenSearch-Dashboards/plugins/dashboards-assistant/coverage/
 
   tests-windows-macos:
     name: Run unit tests
@@ -111,4 +111,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./clover.xml
+          directory: ./

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@
 
 # fix extra path prefix appended in yml to generate report correctly
 fixes:
-  - '/__w/dashboards-assistant/dashboards-assistant/OpenSearch-Dashboards/plugins/dashboards-assistant/::dashboards-assistant/'
+  - '/__w/dashboards-assistant/dashboards-assistant/OpenSearch-Dashboards/plugins/::'

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,5 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- fixes:
-  - "/__w/dashboards-assistant/dashboards-assistant/OpenSearch-Dashboards/plugins/::"
+# fix extra path prefix appended in yml to generate report correctly
+fixes:
+  - "/__w/dashboards-assistant/dashboards-assistant/OpenSearch-Dashboards/plugins/dashboards-assistant/::dashboards-assistant/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,6 @@
-/*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- */
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
 
 # fix extra path prefix appended in yml to generate report correctly
 fixes:
-  - "/__w/dashboards-assistant/dashboards-assistant/OpenSearch-Dashboards/plugins/dashboards-assistant/::dashboards-assistant/"
+  - '/__w/dashboards-assistant/dashboards-assistant/OpenSearch-Dashboards/plugins/dashboards-assistant/::dashboards-assistant/'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ fixes:
+  - "/__w/dashboards-assistant/dashboards-assistant/OpenSearch-Dashboards/plugins/::"

--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -25,6 +25,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 ### Infrastructure
 
 - Fix failed UTs with OSD 3.0 ([#527](https://github.com/opensearch-project/dashboards-assistant/pull/527))
+- Fix empty codecov report in CI([#544](https://github.com/opensearch-project/dashboards-assistant/pull/544))
 
 ### Maintenance
 


### PR DESCRIPTION
### Description
fix empty codecov report in CI


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
