### PR TITLE
Prevent user from navigating to t2viz from discover if ppl return no results/error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Buffer for special characters ([#549](https://github.com/opensearch-project/dashboards-assistant/pull/549))
 - Save chatbot flyout visualize state to local storage ([#553](https://github.com/opensearch-project/dashboards-assistant/pull/553))
+- Prevent user from navigating to t2viz from discover if ppl return no results/error ([#546](https://github.com/opensearch-project/dashboards-assistant/pull/546))
 
 ### Bug Fixes
 

--- a/public/components/ui_action_context_menu.test.tsx
+++ b/public/components/ui_action_context_menu.test.tsx
@@ -124,18 +124,6 @@ describe('ActionContextMenu', () => {
 
   it('should disable the button and show tooltip when there is an error or no results in search.df.df$', async () => {
     // mockProps.data.search.df.df$ = { hasError: true, value: { size: 0 } };
-    const initialPanelValue = [
-      {
-        items: [
-          {
-            'data-test-subj': 'embeddablePanelAction-assistant_generate_visualization_action',
-            disabled: false,
-            toolTipContent: '',
-            onClick: () => {},
-          },
-        ],
-      },
-    ];
     const newIsSummaryAgentAvailable$ = new BehaviorSubject<boolean>(false);
     const newMockAgentConfigExists = jest.fn().mockResolvedValue({ exists: false });
     const newMockProps = {

--- a/public/components/ui_action_context_menu.test.tsx
+++ b/public/components/ui_action_context_menu.test.tsx
@@ -39,7 +39,14 @@ describe('ActionContextMenu', () => {
     mockProps = {
       label: 'OpenSearch Assistant',
       httpSetup: httpServiceMock.createSetupContract(),
-      data: dataPluginMock.createSetupContract(),
+      data: {
+        ...dataPluginMock.createSetupContract(),
+        search: {
+          df: {
+            df$: { hasError: true, value: { size: 0 } },
+          },
+        },
+      },
       resultSummaryEnabled$,
       isQuerySummaryCollapsed$,
       isSummaryAgentAvailable$,
@@ -113,5 +120,52 @@ describe('ActionContextMenu', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('queryAssist_summary_switch')).not.toBeInTheDocument();
     });
+  });
+
+  it('should disable the button and show tooltip when there is an error or no results in search.df.df$', async () => {
+    // mockProps.data.search.df.df$ = { hasError: true, value: { size: 0 } };
+    const initialPanelValue = [
+      {
+        items: [
+          {
+            'data-test-subj': 'embeddablePanelAction-assistant_generate_visualization_action',
+            disabled: false,
+            toolTipContent: '',
+            onClick: () => {},
+          },
+        ],
+      },
+    ];
+    const newIsSummaryAgentAvailable$ = new BehaviorSubject<boolean>(false);
+    const newMockAgentConfigExists = jest.fn().mockResolvedValue({ exists: false });
+    const newMockProps = {
+      ...mockProps,
+      isSummaryAgentAvailable$: newIsSummaryAgentAvailable$,
+      assistantServiceStart: {
+        ...mockProps.assistantServiceStart,
+        client: ({
+          ...mockProps.assistantServiceStart.client,
+          agentConfigExists: newMockAgentConfigExists,
+        } as unknown) as AssistantClient,
+      },
+      data: {
+        aaa: 1111,
+        ...dataPluginMock.createSetupContract(),
+        search: {
+          df: {
+            df$: { hasError: true, value: { size: 0 } },
+          },
+        },
+      },
+    };
+    render(<ActionContextMenu {...newMockProps} />);
+
+    const button1 = screen.getByLabelText('OpenSearch assistant trigger button');
+    fireEvent.click(button1);
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    expect(consoleLogSpy);
+    consoleLogSpy.mockRestore();
+    const popover = await screen.findByTestId('popover-test-id', {}, { timeout: 3000 });
+    expect(popover).toBeInTheDocument();
   });
 });

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -41,8 +41,10 @@ export const ActionContextMenu = (props: Props) => {
   const [open, setOpen] = useState(false);
   const { search } = props.data;
   const [actionContext, setActionContext] = useState({
-    disabled: false,
-    tooltip: '',
+    searchState: {
+      hasError: search.df.df$.hasError,
+      results: search.df.df$.value?.size,
+    },
     datasetId: props.data.query.queryString.getQuery().dataset?.id ?? '',
     datasetType: props.data.query.queryString.getQuery().dataset?.type ?? '',
     dataSourceId: props.data.query.queryString.getQuery().dataset?.dataSource?.id,
@@ -103,21 +105,17 @@ export const ActionContextMenu = (props: Props) => {
       actionContext.datasetId,
       actionContext.datasetType,
       actionContext.dataSourceId,
-      actionContext.disabled,
+      actionContext.searchState,
     ]
   );
 
   useEffect(() => {
-    const buttonDisabled = search.df.df$.hasError || search.df.df$.value?.size === 0;
     setActionContext({
       ...actionContext,
-      disabled: buttonDisabled,
-      tooltip: buttonDisabled
-        ? i18n.translate('dashboardAssistant.queryAssist.generate.visualization.error.message', {
-            defaultMessage:
-              'Generate visualization button was disabled because of No Results/Error.',
-          })
-        : '',
+      searchState: {
+        hasError: search.df.df$.hasError,
+        results: search.df.df$.value?.size,
+      },
     });
   }, [search.df.df$.hasError, search.df.df$.value?.size]);
 

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -144,6 +144,7 @@ export const ActionContextMenu = (props: Props) => {
 
   return (
     <EuiPopover
+      data-test-subj="popover-test-id"
       button={
         <EuiToolTip
           content={

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -43,7 +43,7 @@ export const ActionContextMenu = (props: Props) => {
   const [actionContext, setActionContext] = useState({
     searchState: {
       hasError: search.df.df$.hasError,
-      results: search.df.df$.value?.size,
+      results: search.df.df$.value,
     },
     datasetId: props.data.query.queryString.getQuery().dataset?.id ?? '',
     datasetType: props.data.query.queryString.getQuery().dataset?.type ?? '',
@@ -114,10 +114,10 @@ export const ActionContextMenu = (props: Props) => {
       ...actionContext,
       searchState: {
         hasError: search.df.df$.hasError,
-        results: search.df.df$.value?.size,
+        results: search.df.df$.value,
       },
     });
-  }, [search.df.df$.hasError, search.df.df$.value?.size]);
+  }, [search.df.df$.hasError, search.df.df$.value]);
 
   // The action button should be not displayed when there is no action and result summary disabled or there is no data2Summary agent
   if (!shouldShowSummarizationAction && actionsRef.current.length === 0) {

--- a/public/components/ui_action_context_menu.tsx
+++ b/public/components/ui_action_context_menu.tsx
@@ -117,28 +117,26 @@ export const ActionContextMenu = (props: Props) => {
     !shouldShowSummarizationAction && (panels.value?.[0]?.items ?? []).length === 0;
 
   const openSearchAssistantOnClick = () => {
-    if (search.df.df$.hasError || search.df.df$.value?.size === 0) {
-      const newPanelValue = panelValue;
-      newPanelValue?.forEach((panel) => {
-        panel.items?.forEach((item) => {
-          if (
-            item['data-test-subj'] ===
-            'embeddablePanelAction-assistant_generate_visualization_action'
-          ) {
-            item.disabled = true;
-            item.toolTipContent = i18n.translate(
-              'dashboardAssistant.queryAssist.generate.visualization.error.message',
-              {
-                defaultMessage:
-                  'Generate visualization button was disabled because of No Results/Error.',
-              }
-            );
-            item.onClick = () => {};
-          }
-        });
+    const buttonDisabled = search.df.df$.hasError || search.df.df$.value?.size === 0;
+
+    const newPanelValue = panelValue;
+    newPanelValue?.forEach((panel) => {
+      panel.items?.forEach((item) => {
+        if (item.id === 'assistant_generate_visualization_action') {
+          item.disabled = buttonDisabled;
+          item.toolTipContent = buttonDisabled
+            ? i18n.translate(
+                'dashboardAssistant.queryAssist.generate.visualization.error.message',
+                {
+                  defaultMessage:
+                    'Generate visualization button was disabled because of No Results/Error.',
+                }
+              )
+            : '';
+        }
       });
-      setPanelValue(newPanelValue);
-    }
+    });
+    setPanelValue(newPanelValue);
     setOpen(!open);
   };
 

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -393,7 +393,7 @@ export class AssistantPlugin
         getTooltip: (context) => {
           const { searchState } = context;
           const { hasError, results } = searchState || {};
-          if (hasError || results === 0)
+          if (hasError || results?.size === 0)
             return i18n.translate(
               'dashboardAssistant.queryAssist.generate.visualization.error.message',
               {
@@ -406,7 +406,7 @@ export class AssistantPlugin
         isDisabled: (context) => {
           const { searchState } = context;
           const { hasError, results } = searchState || {};
-          return hasError || results === 0;
+          return hasError || results?.size === 0;
         },
         getIconType: () => 'visLine' as const,
         // T2Viz is only compatible with data sources that have certain agents configured

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -388,16 +388,22 @@ export class AssistantPlugin
         order: 1,
         getDisplayName: () => 'Generate visualization',
         getTooltip: (context) => {
-          if (context?.tooltip) {
-            return context.tooltip;
-          }
+          const { searchState } = context;
+          const { hasError, results } = searchState || {};
+          if (hasError || results === 0)
+            return i18n.translate(
+              'dashboardAssistant.queryAssist.generate.visualization.error.message',
+              {
+                defaultMessage:
+                  'Generate visualization button was disabled because of No Results/Error.',
+              }
+            );
           return '';
         },
         isDisabled: (context) => {
-          if (context?.disabled) {
-            return context.disabled;
-          }
-          return false;
+          const { searchState } = context;
+          const { hasError, results } = searchState || {};
+          return hasError || results === 0;
         },
         getIconType: () => 'visLine' as const,
         // T2Viz is only compatible with data sources that have certain agents configured

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -387,6 +387,18 @@ export class AssistantPlugin
         id: 'assistant_generate_visualization_action',
         order: 1,
         getDisplayName: () => 'Generate visualization',
+        getTooltip: (context) => {
+          if (context?.tooltip) {
+            return context.tooltip;
+          }
+          return '';
+        },
+        isDisabled: (context) => {
+          if (context?.disabled) {
+            return context.disabled;
+          }
+          return false;
+        },
         getIconType: () => 'visLine' as const,
         // T2Viz is only compatible with data sources that have certain agents configured
         isCompatible: async (context) => {

--- a/public/ui_triggers.ts
+++ b/public/ui_triggers.ts
@@ -13,6 +13,8 @@ declare module '../../../src/plugins/ui_actions/public' {
       datasetId: string;
       datasetType: string;
       dataSourceId?: string;
+      disabled?: boolean;
+      tooltip?: string;
     };
   }
 }

--- a/public/ui_triggers.ts
+++ b/public/ui_triggers.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { IDataFrame } from '../../../src/plugins/data/common';
 import { Trigger, UiActionsSetup } from '../../../src/plugins/ui_actions/public';
 
 export const AI_ASSISTANT_QUERY_EDITOR_TRIGGER = 'AI_ASSISTANT_QUERY_EDITOR_TRIGGER';
@@ -15,7 +16,7 @@ declare module '../../../src/plugins/ui_actions/public' {
       dataSourceId?: string;
       searchState?: {
         hasError: boolean;
-        results: number | undefined;
+        results: IDataFrame | undefined;
       };
     };
   }

--- a/public/ui_triggers.ts
+++ b/public/ui_triggers.ts
@@ -13,8 +13,10 @@ declare module '../../../src/plugins/ui_actions/public' {
       datasetId: string;
       datasetType: string;
       dataSourceId?: string;
-      disabled?: boolean;
-      tooltip?: string;
+      searchState?: {
+        hasError: boolean;
+        results: number | undefined;
+      };
     };
   }
 }

--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -15,6 +15,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 - Change chatbot entry point to a single button ([#540](https://github.com/opensearch-project/dashboards-assistant/pull/540))
 - Support streaming output([#493](https://github.com/opensearch-project/dashboards-assistant/pull/493))
 - Update event names for t2v and feedback ([#543](https://github.com/opensearch-project/dashboards-assistant/pull/543))
+- prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result ([#546](https://github.com/opensearch-project/dashboards-assistant/pull/546))
 
 ### Bug Fixes
 

--- a/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/dashboards-assistant.release-notes-3.0.0.0-beta1.md
@@ -15,7 +15,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-beta1
 - Change chatbot entry point to a single button ([#540](https://github.com/opensearch-project/dashboards-assistant/pull/540))
 - Support streaming output([#493](https://github.com/opensearch-project/dashboards-assistant/pull/493))
 - Update event names for t2v and feedback ([#543](https://github.com/opensearch-project/dashboards-assistant/pull/543))
-- prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result ([#546](https://github.com/opensearch-project/dashboards-assistant/pull/546))
+- Prevent user from navigating to t2viz from discover if ppl cannot be run or return 0 result ([#546](https://github.com/opensearch-project/dashboards-assistant/pull/546))
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Description
prevent user from navigating to t2viz from discover if ppl return no results/error

### Issues Resolved



https://github.com/user-attachments/assets/f1b0d44a-c9ca-4fcb-a8bb-751745b1ae6a









### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
