### PR TITLE
Support log pattern in discover summary 

### DIFF
--- a/server/routes/summary_routes.ts
+++ b/server/routes/summary_routes.ts
@@ -16,6 +16,7 @@ import { AgentNotFoundError } from './errors';
 const SUMMARY_AGENT_CONFIG_ID = 'os_summary';
 const LOG_PATTERN_SUMMARY_AGENT_CONFIG_ID = 'os_summary_with_log_pattern';
 const DATA2SUMMARY_AGENT_CONFIG_ID = 'os_data2summary';
+const LOG_PATTERN_DATA2SUMMARY_AGENT_CONFIG_ID = 'os_data2summary_with_log_pattern';
 
 export function postProcessing(output: string) {
   const pattern = /<summarization>(.*?)<\/summarization>.*?<final insights>(.*?)<\/final insights>/s;
@@ -192,6 +193,7 @@ export function registerData2SummaryRoutes(
           total_count: schema.maybe(schema.number()),
           question: schema.maybe(schema.string()),
           ppl: schema.maybe(schema.string()),
+          index: schema.maybe(schema.string()),
         }),
         query: schema.object({
           dataSourceId: schema.maybe(schema.string()),
@@ -201,16 +203,32 @@ export function registerData2SummaryRoutes(
     router.handleLegacyErrors(async (context, req, res) => {
       const assistantClient = assistantService.getScopedClient(req, context);
       try {
-        const response = await assistantClient.executeAgentByConfigName(
-          DATA2SUMMARY_AGENT_CONFIG_ID,
-          {
-            sample_data: req.body.sample_data,
-            total_count: req.body.total_count,
-            sample_count: req.body.sample_count,
-            ppl: req.body.ppl,
-            question: req.body.question,
-          }
-        );
+        const client = await getOpenSearchClientTransport({
+          context,
+          dataSourceId: req.query.dataSourceId,
+        });
+
+        let isLogIndex = false;
+        if (req.body.index) {
+          isLogIndex = await detectIndexType(
+            client,
+            assistantClient,
+            req.body.index,
+            req.query.dataSourceId
+          );
+        }
+
+        const agentConfigId = isLogIndex
+          ? LOG_PATTERN_DATA2SUMMARY_AGENT_CONFIG_ID
+          : DATA2SUMMARY_AGENT_CONFIG_ID;
+
+        const response = await assistantClient.executeAgentByConfigName(agentConfigId, {
+          sample_data: req.body.sample_data,
+          total_count: req.body.total_count,
+          sample_count: req.body.sample_count,
+          ppl: req.body.ppl,
+          question: req.body.question,
+        });
 
         let result = response.body.inference_results[0].output[0].result;
 


### PR DESCRIPTION
### Description
Support log pattern in discover summary 
If the index pattern is log pattern, the discovery summary will call `os_data2summary_with_log_pattern` agent


https://github.com/user-attachments/assets/cbdac12c-e732-4286-95f1-d667b0a06e36




### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
