### PR TITLE
Save chatbot flyout visualize state to local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 - Buffer for special characters ([#549](https://github.com/opensearch-project/dashboards-assistant/pull/549))
+- Save chatbot flyout visualize state to local storage ([#553](https://github.com/opensearch-project/dashboards-assistant/pull/553))
 
 ### Bug Fixes
 

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -5,9 +5,15 @@
 
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useEffectOnce, useObservable } from 'react-use';
+import { useEffectOnce, useObservable, useUpdateEffect } from 'react-use';
+import { debounceTime } from 'rxjs/operators';
 
-import { ApplicationStart, HeaderVariant, SIDECAR_DOCKED_MODE } from '../../../src/core/public';
+import {
+  ApplicationStart,
+  HeaderVariant,
+  MountPoint,
+  SIDECAR_DOCKED_MODE,
+} from '../../../src/core/public';
 import { getIncontextInsightRegistry } from './services';
 import { ChatFlyout } from './chat_flyout';
 import { ChatContext, IChatContext } from './contexts/chat_context';
@@ -24,6 +30,12 @@ import { useCore } from './contexts/core_context';
 import { MountPointPortal } from '../../../src/plugins/opensearch_dashboards_react/public';
 import { usePatchFixedStyle } from './hooks/use_patch_fixed_style';
 import { getLogoIcon } from './services';
+import {
+  getChatbotOpenStatus,
+  getChatbotState,
+  setChatbotOpenStatus,
+  setChatbotSidecarConfig,
+} from './utils/persisted_chatbot_state';
 
 interface HeaderChatButtonProps {
   application: ApplicationStart;
@@ -36,33 +48,86 @@ interface HeaderChatButtonProps {
 
 export const HeaderChatButton = (props: HeaderChatButtonProps) => {
   const core = useCore();
-  const { inLegacyHeader } = props;
   const sideCarRef = useRef<{ close: Function }>();
   const [appId, setAppId] = useState<string>();
   const [conversationId, setConversationId] = useState<string>();
   const [title, setTitle] = useState<string>();
-  const [flyoutVisible, setFlyoutVisible] = useState(false);
+  const [flyoutVisible, setFlyoutVisible] = useState(() => getChatbotOpenStatus());
   const [flyoutComponent, setFlyoutComponent] = useState<React.ReactNode | null>(null);
   const [selectedTabId, setSelectedTabId] = useState<TabId>(TAB_ID.CHAT);
   const [preSelectedTabId, setPreSelectedTabId] = useState<TabId | undefined>(undefined);
   const [interactionId, setInteractionId] = useState<string | undefined>(undefined);
-  const [inputFocus, setInputFocus] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const flyoutLoadedRef = useRef(false);
   const flyoutVisibleRef = useRef(flyoutVisible);
   flyoutVisibleRef.current = flyoutVisible;
   const registry = getIncontextInsightRegistry();
   const headerVariant = useObservable(core.services.chrome.getHeaderVariant$());
   const isSingleLineHeader = headerVariant === HeaderVariant.APPLICATION;
 
-  const [sidecarDockedMode, setSidecarDockedMode] = useState(DEFAULT_SIDECAR_DOCKED_MODE);
+  const [sidecarDockedMode, setSidecarDockedMode] = useState(
+    () => getChatbotState()?.sidecarConfig?.dockedMode || DEFAULT_SIDECAR_DOCKED_MODE
+  );
   const flyoutFullScreen = sidecarDockedMode === SIDECAR_DOCKED_MODE.TAKEOVER;
   const flyoutMountPoint = useRef(null);
   usePatchFixedStyle();
 
+  const loadLatestConversation = () => {
+    core.services.conversations
+      .load({
+        page: 1,
+        perPage: 1,
+        fields: ['createdTimeMs', 'updatedTimeMs', 'title'],
+        sortField: 'updatedTimeMs',
+        sortOrder: 'DESC',
+        searchFields: ['title'],
+      })
+      .then(() => {
+        const data = core.services.conversations.conversations$.getValue();
+        if (data?.objects?.length) {
+          const { id } = data.objects[0];
+          props.assistantActions.loadChat(id);
+        }
+      });
+  };
+
+  const openSidecar = useCallback((mountPoint: MountPoint) => {
+    sideCarRef.current = core.overlays.sidecar().open(mountPoint, {
+      className: 'chatbot-sidecar',
+      config: {
+        dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
+        paddingSize: DEFAULT_SIDECAR_LEFT_OR_RIGHT_SIZE,
+        ...getChatbotState()?.sidecarConfig,
+        isHidden: false,
+      },
+    });
+  }, []);
+
   useEffectOnce(() => {
     const subscription = props.application.currentAppId$.subscribe((id) => setAppId(id));
-    return () => subscription.unsubscribe();
+    const sidecarConfig$Subscription = core.overlays
+      .sidecar()
+      .getSidecarConfig$()
+      .pipe(debounceTime(30))
+      .subscribe((newSidecarConfig) => {
+        if (newSidecarConfig) {
+          setChatbotSidecarConfig(newSidecarConfig);
+        }
+      });
+    let timeoutId: number;
+    if (flyoutVisible) {
+      // Add setTimeout here to avoid "container was removed without using React." error
+      timeoutId = window.setTimeout(() => {
+        if (flyoutMountPoint.current) {
+          loadLatestConversation();
+          openSidecar(flyoutMountPoint.current);
+        }
+      }, 0);
+    }
+    return () => {
+      window.clearTimeout(timeoutId);
+      subscription.unsubscribe();
+      sidecarConfig$Subscription.unsubscribe();
+    };
   });
 
   const chatContextValue: IChatContext = useMemo(
@@ -109,26 +174,19 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
     ]
   );
 
-  useEffect(() => {
-    if (!flyoutLoadedRef.current && flyoutVisible) {
+  useUpdateEffect(() => {
+    if (flyoutVisible) {
       const mountPoint = flyoutMountPoint.current;
-      if (mountPoint) {
-        sideCarRef.current = core.overlays.sidecar().open(mountPoint, {
-          className: 'chatbot-sidecar',
-          config: {
-            dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
-            paddingSize: DEFAULT_SIDECAR_LEFT_OR_RIGHT_SIZE,
-            isHidden: false,
-          },
-        });
-        flyoutLoadedRef.current = true;
+      if (sideCarRef.current) {
+        core.overlays.sidecar().show();
+      } else if (mountPoint) {
+        openSidecar(mountPoint);
       }
-    } else if (flyoutLoadedRef.current && flyoutVisible) {
-      core.overlays.sidecar().show();
-    } else if (flyoutLoadedRef.current && !flyoutVisible) {
+    } else if (sideCarRef.current) {
       core.overlays.sidecar().hide();
     }
-  }, [flyoutVisible]);
+    setChatbotOpenStatus(flyoutVisible);
+  }, [flyoutVisible, openSidecar]);
 
   const setMountPoint = useCallback((mountPoint) => {
     flyoutMountPoint.current = mountPoint;
@@ -201,27 +259,12 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
     };
   }, [appId, flyoutVisible, props.assistantActions, registry]);
 
-  const toggleFlyoutAndloadLatestConversation = () => {
+  const toggleFlyoutAndLoadLatestConversation = () => {
     setFlyoutVisible(!flyoutVisible);
     if (flyoutVisible) {
       return;
     }
-    core.services.conversations
-      .load({
-        page: 1,
-        perPage: 1,
-        fields: ['createdTimeMs', 'updatedTimeMs', 'title'],
-        sortField: 'updatedTimeMs',
-        sortOrder: 'DESC',
-        searchFields: ['title'],
-      })
-      .then(() => {
-        const data = core.services.conversations.conversations$.getValue();
-        if (data?.objects?.length) {
-          const { id } = data.objects[0];
-          props.assistantActions.loadChat(id);
-        }
-      });
+    loadLatestConversation();
   };
 
   return (
@@ -230,7 +273,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
         <EuiButtonIcon
           className={'llm-chat-header-text-input'}
           iconType={getLogoIcon('gradient')}
-          onClick={toggleFlyoutAndloadLatestConversation}
+          onClick={toggleFlyoutAndLoadLatestConversation}
           display={isSingleLineHeader ? 'base' : 'empty'}
           size="s"
           aria-label="toggle chat flyout icon"

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -113,18 +113,18 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
           setChatbotSidecarConfig(newSidecarConfig);
         }
       });
-    let timeoutId: number;
+    let rafId: number;
     if (flyoutVisible) {
-      // Add setTimeout here to avoid "container was removed without using React." error
-      timeoutId = window.setTimeout(() => {
+      // Add window.requestAnimationFrame here to avoid chatbot flyout not displayed after page switching
+      rafId = window.requestAnimationFrame(() => {
         if (flyoutMountPoint.current) {
           loadLatestConversation();
           openSidecar(flyoutMountPoint.current);
         }
-      }, 0);
+      });
     }
     return () => {
-      window.clearTimeout(timeoutId);
+      window.cancelAnimationFrame(rafId);
       subscription.unsubscribe();
       sidecarConfig$Subscription.unsubscribe();
     };

--- a/public/contexts/chat_header_button_store.ts
+++ b/public/contexts/chat_header_button_store.ts
@@ -1,0 +1,4 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/public/contexts/chat_header_button_store.ts
+++ b/public/contexts/chat_header_button_store.ts
@@ -1,4 +1,0 @@
-/*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- */

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -20,6 +20,7 @@ import {
   toMountPoint,
 } from '../../../src/plugins/opensearch_dashboards_react/public';
 import { createGetterSetter } from '../../../src/plugins/opensearch_dashboards_utils/common';
+import { Storage } from '../../../src/plugins/opensearch_dashboards_utils/public';
 import { HeaderChatButton } from './chat_header_button';
 import { AssistantServices } from './contexts/core_context';
 import {
@@ -44,6 +45,7 @@ import {
   setExpressions,
   setHttp,
   setAssistantService,
+  setLocalStorage,
 } from './services';
 import { ConfigSchema } from '../common/types/config';
 import { DataSourceService } from './services/data_source_service';
@@ -70,7 +72,7 @@ import {
   ASSISTANT_INPUT_URL_SEARCH_KEY,
   INDEX_PATTERN_URL_SEARCH_KEY,
 } from './components/visualization/text2viz';
-import { DEFAULT_DATA } from '../../../src/plugins/data/common';
+import { DEFAULT_DATA, createStorage } from '../../../src/plugins/data/common';
 
 export const [getCoreStart, setCoreStart] = createGetterSetter<CoreStart>('CoreStart');
 
@@ -381,6 +383,7 @@ export class AssistantPlugin
     setConfigSchema(this.config);
     setUiActions(uiActions);
     setAssistantService(assistantServiceStart);
+    setLocalStorage(createStorage({ engine: window.localStorage, prefix: 'dashboardsAssistant.' }));
 
     if (this.config.text2viz.enabled) {
       uiActions.addTriggerAction(AI_ASSISTANT_QUERY_EDITOR_TRIGGER, {

--- a/public/services/index.ts
+++ b/public/services/index.ts
@@ -6,6 +6,7 @@
 import { createGetterSetter } from '../../../../src/plugins/opensearch_dashboards_utils/public';
 import { UiActionsStart } from '../../../../src/plugins/ui_actions/public';
 import { ChromeStart, HttpStart, NotificationsStart } from '../../../../src/core/public';
+import { DataStorage } from '../../../../src/plugins/data/common';
 import { IncontextInsightRegistry } from './incontext_insight';
 import { ConfigSchema } from '../../common/types/config';
 import { IndexPatternsContract } from '../../../../src/plugins/data/public';
@@ -42,6 +43,8 @@ export const [getHttp, setHttp] = createGetterSetter<HttpStart>('Http');
 export const [getAssistantService, setAssistantService] = createGetterSetter<AssistantServiceStart>(
   'AssistantServiceStart'
 );
+
+export const [getLocalStorage, setLocalStorage] = createGetterSetter<DataStorage>('LocalStorage');
 
 export { DataSourceService, DataSourceServiceContract } from './data_source_service';
 

--- a/public/utils/persisted_chatbot_state.test.ts
+++ b/public/utils/persisted_chatbot_state.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getChatbotOpenStatus,
+  setChatbotOpenStatus,
+  setChatbotSidecarConfig,
+  getChatbotState,
+  setChatbotState,
+  ChatbotState,
+} from './persisted_chatbot_state';
+import { getLocalStorage } from '../services';
+import { SIDECAR_DOCKED_MODE } from '../../../../src/core/public';
+
+// Mock the services module
+jest.mock('../services', () => ({
+  getLocalStorage: jest.fn(),
+}));
+
+describe('Persisted chatbot state utils', () => {
+  let mockLocalStorage: {
+    get: jest.Mock;
+    set: jest.Mock;
+  };
+
+  beforeEach(() => {
+    // Set up mock local storage
+    mockLocalStorage = {
+      get: jest.fn(),
+      set: jest.fn(),
+    };
+    (getLocalStorage as jest.Mock).mockReturnValue(mockLocalStorage);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getChatbotState', () => {
+    it('should retrieve chatbot state from local storage', () => {
+      const mockState: ChatbotState = { isOpen: true };
+      mockLocalStorage.get.mockReturnValue(mockState);
+
+      const result = getChatbotState();
+
+      expect(mockLocalStorage.get).toHaveBeenCalledWith('chatbotState');
+      expect(result).toEqual(mockState);
+    });
+
+    it('should return null if no state is stored', () => {
+      mockLocalStorage.get.mockReturnValue(null);
+
+      const result = getChatbotState();
+
+      expect(mockLocalStorage.get).toHaveBeenCalledWith('chatbotState');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setChatbotState', () => {
+    it('should set chatbot state in local storage', () => {
+      const mockState: ChatbotState = { isOpen: true };
+
+      setChatbotState(mockState);
+
+      expect(mockLocalStorage.set).toHaveBeenCalledWith('chatbotState', mockState);
+    });
+  });
+
+  describe('getChatbotOpenStatus', () => {
+    it('should return true when chatbot is open', () => {
+      mockLocalStorage.get.mockReturnValue({ isOpen: true });
+
+      const result = getChatbotOpenStatus();
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when chatbot is closed', () => {
+      mockLocalStorage.get.mockReturnValue({ isOpen: false });
+
+      const result = getChatbotOpenStatus();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when chatbot state is not set', () => {
+      mockLocalStorage.get.mockReturnValue(null);
+
+      const result = getChatbotOpenStatus();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when isOpen property is not set', () => {
+      mockLocalStorage.get.mockReturnValue({ sidecarConfig: {} });
+
+      const result = getChatbotOpenStatus();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('setChatbotOpenStatus', () => {
+    it('should update isOpen status while preserving existing state', () => {
+      const existingState = {
+        isOpen: false,
+        sidecarConfig: {
+          dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+          paddingSize: 10,
+        },
+      };
+      mockLocalStorage.get.mockReturnValue(existingState);
+
+      setChatbotOpenStatus(true);
+
+      expect(mockLocalStorage.set).toHaveBeenCalledWith('chatbotState', {
+        ...existingState,
+        isOpen: true,
+      });
+    });
+
+    it('should create new state with isOpen when no state exists', () => {
+      mockLocalStorage.get.mockReturnValue(null);
+
+      setChatbotOpenStatus(true);
+
+      expect(mockLocalStorage.set).toHaveBeenCalledWith('chatbotState', { isOpen: true });
+    });
+  });
+
+  describe('setChatbotSidecarConfig', () => {
+    it('should update sidecarConfig while preserving existing state', () => {
+      const existingState = {
+        isOpen: true,
+        sidecarConfig: {
+          dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
+          paddingSize: 10,
+        },
+      };
+      mockLocalStorage.get.mockReturnValue(existingState);
+
+      const newConfig = {
+        isHidden: false,
+        dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+        paddingSize: 20,
+      };
+      setChatbotSidecarConfig(newConfig);
+
+      expect(mockLocalStorage.set).toHaveBeenCalledWith('chatbotState', {
+        ...existingState,
+        sidecarConfig: {
+          dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+          paddingSize: 20,
+        },
+      });
+    });
+
+    it('should create new state with sidecarConfig when no state exists', () => {
+      mockLocalStorage.get.mockReturnValue(null);
+
+      const newConfig = {
+        isHidden: false,
+        dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+        paddingSize: 20,
+      };
+      setChatbotSidecarConfig(newConfig);
+
+      expect(mockLocalStorage.set).toHaveBeenCalledWith('chatbotState', {
+        sidecarConfig: {
+          dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+          paddingSize: 20,
+        },
+      });
+    });
+
+    it('should correctly omit isHidden property from the config', () => {
+      mockLocalStorage.get.mockReturnValue({});
+
+      const newConfig = {
+        isHidden: true,
+        dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+        paddingSize: 20,
+      };
+      setChatbotSidecarConfig(newConfig);
+
+      expect(mockLocalStorage.set).toHaveBeenCalledWith('chatbotState', {
+        sidecarConfig: {
+          dockedMode: SIDECAR_DOCKED_MODE.LEFT,
+          paddingSize: 20,
+        },
+      });
+
+      // Verify isHidden was removed
+      const calledArg = mockLocalStorage.set.mock.calls[0][1];
+      expect(calledArg.sidecarConfig.isHidden).toBeUndefined();
+    });
+  });
+});

--- a/public/utils/persisted_chatbot_state.ts
+++ b/public/utils/persisted_chatbot_state.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ISidecarConfig } from '../../../../src/core/public/overlays/sidecar';
+import { getLocalStorage } from '../services';
+
+export interface ChatbotState {
+  isOpen?: boolean;
+  sidecarConfig?: Omit<ISidecarConfig, 'isHidden'>;
+}
+
+const CHATBOT_STATE_KEY = 'chatbotState';
+
+export const getChatbotOpenStatus = () => getChatbotState()?.isOpen === true;
+
+export const setChatbotOpenStatus = (isOpen: boolean) =>
+  setChatbotState({ ...getChatbotState(), isOpen });
+
+export const setChatbotSidecarConfig = ({ isHidden, ...restConfig }: ISidecarConfig) => {
+  setChatbotState({ ...getChatbotState(), sidecarConfig: restConfig });
+};
+
+export const getChatbotState = (): ChatbotState | null => getLocalStorage().get(CHATBOT_STATE_KEY);
+
+export const setChatbotState = (state: ChatbotState) =>
+  getLocalStorage().set(CHATBOT_STATE_KEY, state);


### PR DESCRIPTION
### Description

This PR save chat flyout visualize state in user browser local storage. The chatbot flyout will keep open when user navigate to other pages after this PR get merged.

See videos below:

https://github.com/user-attachments/assets/e80a87d1-4974-4e6d-954d-7163167ae9e0


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
