### PR TITLE
t2viz generated visualizations should support time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Buffer for special characters ([#549](https://github.com/opensearch-project/dashboards-assistant/pull/549))
 - Save chatbot flyout visualize state to local storage ([#553](https://github.com/opensearch-project/dashboards-assistant/pull/553))
+- T2viz supports reading time range from context ([#557](https://github.com/opensearch-project/dashboards-assistant/pull/557/))
 
 ### Bug Fixes
 

--- a/public/components/visualization/embeddable/nlq_vis_embeddable.ts
+++ b/public/components/visualization/embeddable/nlq_vis_embeddable.ts
@@ -13,7 +13,7 @@ import {
   ExpressionsStart,
   IExpressionLoaderParams,
 } from '../../../../../../src/plugins/expressions/public';
-import { TimeRange } from '../../../../../../src/plugins/data/public';
+import { TimefilterContract, TimeRange } from '../../../../../../src/plugins/data/public';
 import { NLQVisualizationInput, NLQVisualizationOutput } from './types';
 import { getExpressions } from '../../../services';
 import { VIS_NLQ_APP_ID, VIS_NLQ_SAVED_OBJECT } from '../../../../common/constants/vis_type_nlq';
@@ -47,6 +47,7 @@ export class NLQVisualizationEmbeddable extends Embeddable<
   private visInput?: NLQVisualizationInput['visInput'];
 
   constructor(
+    timeFilter: TimefilterContract,
     initialInput: NLQVisualizationInput,
     config?: NLQVisualizationEmbeddableConfig,
     parent?: IContainer
@@ -68,9 +69,15 @@ export class NLQVisualizationEmbeddable extends Embeddable<
     this.uiState = new PersistedState();
     this.visInput = initialInput.visInput;
 
-    this.getInput$().subscribe(() => {
-      this.handleChange();
-    });
+    this.subscriptions.push(
+      this.getInput$().subscribe(() => {
+        this.handleChange();
+      })
+    );
+
+    this.subscriptions.push(
+      timeFilter.getAutoRefreshFetch$().subscribe(() => this.updateHandler())
+    );
   }
 
   /**

--- a/public/components/visualization/embeddable/nlq_vis_embeddable.ts
+++ b/public/components/visualization/embeddable/nlq_vis_embeddable.ts
@@ -71,7 +71,10 @@ export class NLQVisualizationEmbeddable extends Embeddable<
 
     this.subscriptions.push(
       this.getInput$().subscribe(() => {
-        this.handleChange();
+        const dirty = this.dirtyCheck();
+        if (dirty) {
+          this.updateHandler();
+        }
       })
     );
 
@@ -105,7 +108,7 @@ export class NLQVisualizationEmbeddable extends Embeddable<
     return pipeline;
   };
 
-  private handleChange() {
+  private dirtyCheck() {
     let dirty = false;
 
     // Check if timerange has changed
@@ -113,10 +116,7 @@ export class NLQVisualizationEmbeddable extends Embeddable<
       this.timeRange = cloneDeep(this.input.timeRange);
       dirty = true;
     }
-
-    if (dirty) {
-      this.updateHandler();
-    }
+    return dirty;
   }
 
   private updateHandler = async () => {

--- a/public/components/visualization/embeddable/nlq_vis_embeddable.ts
+++ b/public/components/visualization/embeddable/nlq_vis_embeddable.ts
@@ -116,7 +116,7 @@ export class NLQVisualizationEmbeddable extends Embeddable<
     const expressionParams: IExpressionLoaderParams = {
       searchContext: {
         timeRange: this.timeRange,
-        // for PPL+vega, we don't read query and fitlers from input, because these are already defined in vega
+        // for PPL+vega, we don't read query and fitlers from input, because these are already defined by ppl
         // query: this.input.query,
         // filters: this.input.filters,
       },

--- a/public/components/visualization/embeddable/nlq_vis_embeddable.ts
+++ b/public/components/visualization/embeddable/nlq_vis_embeddable.ts
@@ -114,7 +114,7 @@ export class NLQVisualizationEmbeddable extends Embeddable<
       dirty = true;
     }
 
-    if (this.handler && dirty) {
+    if (dirty) {
       this.updateHandler();
     }
   }

--- a/public/components/visualization/embeddable/nlq_vis_embeddable_factory.ts
+++ b/public/components/visualization/embeddable/nlq_vis_embeddable_factory.ts
@@ -19,7 +19,7 @@ import {
 } from './nlq_vis_embeddable';
 import { VIS_NLQ_APP_ID, VIS_NLQ_SAVED_OBJECT } from '../../../../common/constants/vis_type_nlq';
 import { SavedObjectMetaData } from '../../../../../../src/plugins/saved_objects/public';
-import { getHttp } from '../../../services';
+import { getHttp, getTimeFilter } from '../../../services';
 
 export class NLQVisualizationEmbeddableFactory implements EmbeddableFactoryDefinition {
   public readonly type = NLQ_VISUALIZATION_EMBEDDABLE_TYPE;
@@ -54,6 +54,7 @@ export class NLQVisualizationEmbeddableFactory implements EmbeddableFactoryDefin
     try {
       const savedObject: VisNLQSavedObject = await loader.get(savedObjectId);
       return new NLQVisualizationEmbeddable(
+        getTimeFilter(),
         {
           ...input,
           visInput: {
@@ -78,7 +79,12 @@ export class NLQVisualizationEmbeddableFactory implements EmbeddableFactoryDefin
     if (input.visInput) {
       const editPath = `/edit/${input.savedObjectId}`;
       const editUrl = getHttp().basePath.prepend(`/app/${VIS_NLQ_APP_ID}${editPath}`);
-      return new NLQVisualizationEmbeddable(input, { editUrl, editPath, editable: true }, parent);
+      return new NLQVisualizationEmbeddable(
+        getTimeFilter(),
+        input,
+        { editUrl, editPath, editable: true },
+        parent
+      );
     } else {
       return undefined;
     }

--- a/public/components/visualization/text2viz.tsx
+++ b/public/components/visualization/text2viz.tsx
@@ -249,7 +249,7 @@ export const Text2Viz = () => {
         inputQuestion,
         inputInstruction,
         dataSourceId: indexPattern.dataSourceRef?.id,
-        timeFiledName: indexPattern.timeFieldName,
+        timeFieldName: indexPattern.timeFieldName,
       });
 
       if (usageCollection) {

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -44,6 +44,7 @@ import {
   setExpressions,
   setHttp,
   setAssistantService,
+  setTimeFilter,
 } from './services';
 import { ConfigSchema } from '../common/types/config';
 import { DataSourceService } from './services/data_source_service';
@@ -437,6 +438,7 @@ export class AssistantPlugin
     }
 
     setIndexPatterns(data.indexPatterns);
+    setTimeFilter(data.query.timefilter.timefilter);
     setExpressions(expressions);
     setHttp(core.http);
 

--- a/public/services/index.ts
+++ b/public/services/index.ts
@@ -8,7 +8,7 @@ import { UiActionsStart } from '../../../../src/plugins/ui_actions/public';
 import { ChromeStart, HttpStart, NotificationsStart } from '../../../../src/core/public';
 import { IncontextInsightRegistry } from './incontext_insight';
 import { ConfigSchema } from '../../common/types/config';
-import { IndexPatternsContract } from '../../../../src/plugins/data/public';
+import { IndexPatternsContract, TimefilterContract } from '../../../../src/plugins/data/public';
 import { ExpressionsStart } from '../../../../src/plugins/expressions/public';
 import { AssistantServiceStart } from './assistant_service';
 import chatIcon from '../assets/chat.svg';
@@ -38,6 +38,8 @@ export const [getIndexPatterns, setIndexPatterns] = createGetterSetter<IndexPatt
 export const [getExpressions, setExpressions] = createGetterSetter<ExpressionsStart>('Expressions');
 
 export const [getHttp, setHttp] = createGetterSetter<HttpStart>('Http');
+
+export const [getTimeFilter, setTimeFilter] = createGetterSetter<TimefilterContract>('TimeFilter');
 
 export const [getAssistantService, setAssistantService] = createGetterSetter<AssistantServiceStart>(
   'AssistantServiceStart'

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.test.ts
@@ -85,7 +85,7 @@ describe('PPLAutoSuggestTask', () => {
     const input = {
       ppl: 'source = test',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     // Mock successful search response
@@ -109,7 +109,7 @@ describe('PPLAutoSuggestTask', () => {
     const expected = {
       ppl: 'source = test | stats count() by span(timestamp, 1d)',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     const result = await pplAutoSuggestTask.execute(input);
@@ -131,7 +131,7 @@ describe('PPLAutoSuggestTask', () => {
     const input = {
       ppl: 'source = test | fields field1, field2',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     const mockResponse = {
@@ -154,7 +154,7 @@ describe('PPLAutoSuggestTask', () => {
     const expected = {
       ppl: 'source = test | stats count() by span(timestamp, 1d)',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     const result = await pplAutoSuggestTask.execute(input);
@@ -214,7 +214,7 @@ describe('PPLAutoSuggestTask', () => {
     const input = {
       ppl: 'source = test',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     // Mock empty search response
@@ -232,7 +232,7 @@ describe('PPLAutoSuggestTask', () => {
     const expected = {
       ppl: 'source = test | stats count()',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     const result = await pplAutoSuggestTask.execute(input);
@@ -243,7 +243,7 @@ describe('PPLAutoSuggestTask', () => {
     const input = {
       ppl: 'source = test',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     // Mock null search response
@@ -256,7 +256,7 @@ describe('PPLAutoSuggestTask', () => {
     const expected = {
       ppl: 'source = test | stats count()',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     const result = await pplAutoSuggestTask.execute(input);
@@ -267,7 +267,7 @@ describe('PPLAutoSuggestTask', () => {
     const input = {
       ppl: 'source = test',
       dataSourceId: 'test-source',
-      timeFiledName: 'timestamp',
+      timeFieldName: 'timestamp',
     };
 
     mockSearchClient.search.mockReturnValue({

--- a/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
+++ b/public/utils/pipeline/ppl_aggs_auto_suggest_task.ts
@@ -9,7 +9,7 @@ import { DataPublicPluginStart } from '../../../../../src/plugins/data/public';
 interface Input {
   ppl: string;
   dataSourceId: string | undefined;
-  timeFiledName?: string;
+  timeFieldName?: string;
 }
 
 export class PPLAggsAutoSuggestTask extends Task<Input, Input> {
@@ -34,8 +34,8 @@ export class PPLAggsAutoSuggestTask extends Task<Input, Input> {
 
       // if no aggregation, will try auto suggest one
       if (!pplHasAgg) {
-        if (v.timeFiledName) {
-          const dateRangePPL = `${ppl} | stats min(${v.timeFiledName}) as min, max(${v.timeFiledName}) as max`;
+        if (v.timeFieldName) {
+          const dateRangePPL = `${ppl} | stats min(${v.timeFieldName}) as min, max(${v.timeFieldName}) as max`;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           let res: any;
           try {
@@ -56,7 +56,7 @@ export class PPLAggsAutoSuggestTask extends Task<Input, Input> {
               const interval =
                 this.searchClient.aggs.calculateAutoTimeExpression({ from: min, to: max }) || '1d';
 
-              ppl = `${ppl} | stats count() by span(${v.timeFiledName}, ${interval})`;
+              ppl = `${ppl} | stats count() by span(${v.timeFieldName}, ${interval})`;
             }
           } catch (e) {
             ppl = `${ppl} | stats count()`;

--- a/public/utils/pipeline/text_to_ppl_task.ts
+++ b/public/utils/pipeline/text_to_ppl_task.ts
@@ -11,7 +11,7 @@ interface Input {
   inputQuestion: string;
   index: string;
   dataSourceId?: string;
-  timeFiledName?: string;
+  timeFieldName?: string;
 }
 
 export class Text2PPLTask extends Task<Input, Input & { ppl: string }> {

--- a/public/utils/pipeline/text_to_vega_task.test.ts
+++ b/public/utils/pipeline/text_to_vega_task.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { httpServiceMock, savedObjectsServiceMock } from '../../../../../src/core/public/mocks';
+import { Text2VegaTask } from './text_to_vega_task';
+
+describe('Text2VegaTask', () => {
+  it('should return vega schema which escaped `field`', async () => {
+    const httpMock = httpServiceMock.createStartContract();
+    const savedObjectsMock = savedObjectsServiceMock.createStartContract();
+    httpMock.post.mockResolvedValue({
+      $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+      description: 'A bar chart that sorts the y-values by the x-values.',
+      mark: 'bar',
+      encoding: {
+        y: {
+          field: 'user.age',
+          type: 'ordinal',
+        },
+        x: {
+          aggregate: 'sum',
+          field: 'people',
+          title: 'population',
+        },
+      },
+    });
+
+    const task = new Text2VegaTask(httpMock, savedObjectsMock);
+    const res = await task.text2vega({
+      inputQuestion: 'mock question',
+      ppl: 'source=mock_source',
+      sampleData: '',
+      dataSchema: '',
+    });
+    expect(res.encoding.y.field).toEqual('user\\.age');
+  });
+
+  it('should return vega schema which escaped layer `field`', async () => {
+    const httpMock = httpServiceMock.createStartContract();
+    const savedObjectsMock = savedObjectsServiceMock.createStartContract();
+    httpMock.post.mockResolvedValue({
+      $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+      description: 'A bar chart that sorts the y-values by the x-values.',
+      mark: 'bar',
+      layer: [
+        {
+          encoding: {
+            y: {
+              field: 'user.age',
+              type: 'ordinal',
+            },
+            x: {
+              aggregate: 'sum',
+              field: 'people',
+              title: 'population',
+            },
+          },
+        },
+      ],
+    });
+
+    const task = new Text2VegaTask(httpMock, savedObjectsMock);
+    const res = await task.text2vega({
+      inputQuestion: 'mock question',
+      ppl: 'source=mock_source',
+      sampleData: '',
+      dataSchema: '',
+    });
+    expect(res.layer[0].encoding.y.field).toEqual('user\\.age');
+  });
+
+  it('should have data.url properly set', async () => {
+    const httpMock = httpServiceMock.createStartContract();
+    const savedObjectsMock = savedObjectsServiceMock.createStartContract();
+    const task = new Text2VegaTask(httpMock, savedObjectsMock);
+    jest.spyOn(task, 'text2vega').mockResolvedValue({
+      $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+      description: 'A bar chart that sorts the y-values by the x-values.',
+      mark: 'bar',
+      layer: [
+        {
+          encoding: {
+            y: {
+              field: 'user\\.age',
+              type: 'ordinal',
+            },
+            x: {
+              aggregate: 'sum',
+              field: 'people',
+              title: 'population',
+            },
+          },
+        },
+      ],
+    });
+    jest.spyOn(task, 'getDataSourceNameById').mockResolvedValue('mocked_data_source_name');
+    const result = await task.execute({
+      inputQuestion: 'mocked question',
+      dataSourceId: 'test',
+      ppl: 'source=test',
+      inputInstruction: '',
+      sample: {},
+      timeFieldName: 'timestamp',
+    });
+    // %fimefield% is set
+    // %type% is set to ppl
+    // body.query is set to the input ppl query
+    // data_source_name is set
+    expect(result.vega.data.url).toEqual({
+      '%type%': 'ppl',
+      '%timefield%': 'timestamp',
+      body: { query: 'source=test' },
+      data_source_name: 'mocked_data_source_name',
+    });
+  });
+});

--- a/public/utils/pipeline/text_to_vega_task.ts
+++ b/public/utils/pipeline/text_to_vega_task.ts
@@ -7,7 +7,6 @@ import { Task } from './task';
 import { HttpSetup, SavedObjectsStart } from '../../../../../src/core/public';
 import { TEXT2VIZ_API } from '../../../common/constants/llm';
 import { DataSourceAttributes } from '../../../../../src/plugins/data_source/common/data_sources';
-import { TimeField } from '../../../../../src/plugins/index_pattern_management/public/components/create_index_pattern_wizard/components/step_time_field/components/time_field';
 
 interface Input {
   inputQuestion: string;

--- a/public/utils/tests/alerting.test.ts
+++ b/public/utils/tests/alerting.test.ts
@@ -12,7 +12,7 @@ describe('extractTimeRangeDSL', () => {
     );
   });
 
-  it('should return undefined timeFiledName if no time range filter', () => {
+  it('should return undefined timeFieldName if no time range filter', () => {
     expect(
       extractTimeRangeDSL([
         {
@@ -22,7 +22,7 @@ describe('extractTimeRangeDSL', () => {
     ).toBe(undefined);
   });
 
-  it('should extract timeFiledName normally', () => {
+  it('should extract timeFieldName normally', () => {
     expect(
       extractTimeRangeDSL([
         {


### PR DESCRIPTION
### Description
1. Support reading time range from context for visualizations generated by t2viz
2. Fixed a typo timeFiledName -> timeFieldName

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
