### PR TITLE
Upgrade derek-ho/start-opensearch to v6 and set java version to 21 for OS 3.0

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -29,10 +29,11 @@ jobs:
         shell: bash
 
       - name: Run Opensearch
-        uses: derek-ho/start-opensearch@v2
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false
+          jdk-version: 21
 
       - name: Run Dashboard
         id: setup-dashboards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Maintenance
 
+- Upgrade derek-ho/start-opensearch to v6 and set java version to 21 for OS 3.0([#563](https://github.com/opensearch-project/dashboards-assistant/pull/563))
+
 ### Refactoring


### PR DESCRIPTION
### Description

start with OpenSearch 3.0 it will requires java version be 21+, upgrade ` derek-ho/start-opensearch` to v6 and set java version to 21

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
