### PR TITLE
Add format instruction for alert summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Buffer for special characters ([#549](https://github.com/opensearch-project/dashboards-assistant/pull/549))
 - Save chatbot flyout visualize state to local storage ([#553](https://github.com/opensearch-project/dashboards-assistant/pull/553))
 - Improve the chatbot UX by scroll the user input message to the top after sending ([#545](https://github.com/opensearch-project/dashboards-assistant/pull/545))
+- Add format instruction for alert summary ([#568](https://github.com/opensearch-project/dashboards-assistant/pull/568))
 
 ### Bug Fixes
 

--- a/public/components/incontext_insight/generate_popover_body.tsx
+++ b/public/components/incontext_insight/generate_popover_body.tsx
@@ -111,11 +111,33 @@ export const GeneratePopoverBody: React.FC<{
   }, [contextObject, setDisplayDiscoverButton]);
 
   useEffectOnce(() => {
-    onGenerateSummary(
+    const summaryInstructions =
       incontextInsight.suggestions && incontextInsight.suggestions.length > 0
         ? incontextInsight.suggestions[0]
-        : 'Please summarize the input'
-    );
+        : 'Please summarize the input';
+
+    // append format instructions
+    const finalInstructions = `${summaryInstructions}, And output should follow format instructions defined in \`output_format\` tag
+    <output_format>
+    **Summary**
+    - Provide a concise paragraph that:
+      1. States the core issue/alert
+      2. Describes the impact/severity
+      3. Highlights key metrics or thresholds breached
+    Please don't use bullet points for summary, use paragraph instead.
+
+    **Action Items**
+    - List 3-5 specific, actionable recommendations:
+      1. Mitigation steps
+      2. Investigation points
+
+    Notes:
+    - Include specific numbers/metrics where applicable
+    - Keep technical terms consistent
+    - Link to relevant documentation when available
+    </output_format>`;
+
+    onGenerateSummary(finalInstructions);
   });
 
   const onGenerateSummary = (summarizationQuestion: string) => {

--- a/public/types.ts
+++ b/public/types.ts
@@ -91,7 +91,7 @@ export interface AssistantSetup {
   assistantActions: Omit<AssistantActions, 'executeAction'>;
   assistantTriggers: { AI_ASSISTANT_QUERY_EDITOR_TRIGGER: string };
   registerIncontextInsight: IncontextInsightRegistry['register'];
-  renderIncontextInsight: (component: React.ReactNode) => React.ReactNode;
+  renderIncontextInsight: (component: React.ReactNode) => React.ReactElement;
 }
 
 export interface AssistantStart {
@@ -117,7 +117,7 @@ export type IncontextInsights = Map<string, IncontextInsight>;
 
 export interface ContextObj {
   context: string;
-  additionalInfo: Record<string, string>;
+  additionalInfo: Record<string, unknown>;
   dataSourceId?: string;
 }
 


### PR DESCRIPTION
### Description

Add format instruction for alert summary to make the alert summary output more consistent

![image](https://github.com/user-attachments/assets/6efc80f9-5f97-4b10-94a5-33251685c070)


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
