### PR TITLE
Fix chat page conversation loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - log error body or message instead of the entire error object ([#548](https://github.com/opensearch-project/dashboards-assistant/pull/548))
 - Fix http request for insights to be triggered only after view insights button is clicked ([#520](https://github.com/opensearch-project/dashboards-assistant/pull/520))
+- Fix chat page conversation loading state ([#569](https://github.com/opensearch-project/dashboards-assistant/pull/569))
 
 ### Infrastructure
 

--- a/public/chat_header_button.tsx
+++ b/public/chat_header_button.tsx
@@ -72,35 +72,27 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
   usePatchFixedStyle();
 
   const loadLatestConversation = () => {
-    core.services.conversations
-      .load({
-        page: 1,
-        perPage: 1,
-        fields: ['createdTimeMs', 'updatedTimeMs', 'title'],
-        sortField: 'updatedTimeMs',
-        sortOrder: 'DESC',
-        searchFields: ['title'],
-      })
-      .then(() => {
-        const data = core.services.conversations.conversations$.getValue();
-        if (data?.objects?.length) {
-          const { id } = data.objects[0];
-          props.assistantActions.loadChat(id);
-        }
-      });
+    core.services.conversationLoad.getLatestConversationId().then((latestConversationId) => {
+      if (latestConversationId) {
+        props.assistantActions.loadChat(latestConversationId);
+      }
+    });
   };
 
-  const openSidecar = useCallback((mountPoint: MountPoint) => {
-    sideCarRef.current = core.overlays.sidecar().open(mountPoint, {
-      className: 'chatbot-sidecar',
-      config: {
-        dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
-        paddingSize: DEFAULT_SIDECAR_LEFT_OR_RIGHT_SIZE,
-        ...getChatbotState()?.sidecarConfig,
-        isHidden: false,
-      },
-    });
-  }, []);
+  const openSidecar = useCallback(
+    (mountPoint: MountPoint) => {
+      sideCarRef.current = core.overlays.sidecar().open(mountPoint, {
+        className: 'chatbot-sidecar',
+        config: {
+          dockedMode: SIDECAR_DOCKED_MODE.RIGHT,
+          paddingSize: DEFAULT_SIDECAR_LEFT_OR_RIGHT_SIZE,
+          ...getChatbotState()?.sidecarConfig,
+          isHidden: false,
+        },
+      });
+    },
+    [core.overlays]
+  );
 
   useEffectOnce(() => {
     const subscription = props.application.currentAppId$.subscribe((id) => setAppId(id));
@@ -212,7 +204,7 @@ export const HeaderChatButton = (props: HeaderChatButtonProps) => {
       }
       sideCarRef.current?.close();
     };
-  }, []);
+  }, [core.overlays]);
 
   useEffect(() => {
     const handleSuggestion = async (event: {

--- a/public/services/conversation_load_service.ts
+++ b/public/services/conversation_load_service.ts
@@ -15,7 +15,11 @@ export class ConversationLoadService {
     'idle' | 'loading' | { status: 'error'; error: Error }
   > = new BehaviorSubject<'idle' | 'loading' | { status: 'error'; error: Error }>('idle');
   abortController?: AbortController;
-  readonly conversationsService: ConversationsService;
+  private readonly conversationsService: ConversationsService;
+
+  public get latestIdStatus$() {
+    return this.conversationsService.status$;
+  }
 
   constructor(private _http: HttpStart, private _dataSource: DataSourceService) {
     this.conversationsService = new ConversationsService(_http, _dataSource);

--- a/public/tabs/chat/chat_page.tsx
+++ b/public/tabs/chat/chat_page.tsx
@@ -21,9 +21,7 @@ export const ChatPage: React.FC<ChatPageProps> = (props) => {
   const chatContext = useChatContext();
   const { chatState, chatStateDispatch } = useChatState();
   const conversationLoadStatus = useObservable(core.services.conversationLoad.status$);
-  const conversationsStatus = useObservable(
-    core.services.conversationLoad.conversationsService.status$
-  );
+  const conversationsStatus = useObservable(core.services.conversationLoad.latestIdStatus$);
   const messagesLoading = conversationLoadStatus === 'loading';
   const conversationsLoading = conversationsStatus === 'loading';
 

--- a/public/tabs/chat/chat_page.tsx
+++ b/public/tabs/chat/chat_page.tsx
@@ -21,7 +21,9 @@ export const ChatPage: React.FC<ChatPageProps> = (props) => {
   const chatContext = useChatContext();
   const { chatState, chatStateDispatch } = useChatState();
   const conversationLoadStatus = useObservable(core.services.conversationLoad.status$);
-  const conversationsStatus = useObservable(core.services.conversations.status$);
+  const conversationsStatus = useObservable(
+    core.services.conversationLoad.conversationsService.status$
+  );
   const messagesLoading = conversationLoadStatus === 'loading';
   const conversationsLoading = conversationsStatus === 'loading';
 
@@ -46,7 +48,7 @@ export const ChatPage: React.FC<ChatPageProps> = (props) => {
         },
       });
     }
-  }, [chatContext.conversationId, chatStateDispatch]);
+  }, [chatContext.conversationId, chatStateDispatch, core.services.conversationLoad]);
 
   const { loadChat } = useChatActions();
   const chatScrollTopRef = useRef<{ scrollTop: number; height: number } | null>(null);
@@ -64,33 +66,22 @@ export const ChatPage: React.FC<ChatPageProps> = (props) => {
   };
   const refreshConversationsList = useCallback(async () => {
     if (!chatContext.conversationId) {
-      core.services.conversations
-        .load({
-          page: 1,
-          perPage: 1,
-          fields: ['createdTimeMs', 'updatedTimeMs', 'title'],
-          sortField: 'updatedTimeMs',
-          sortOrder: 'DESC',
-          searchFields: ['title'],
-        })
-        .then(async () => {
-          const data = core.services.conversations.conversations$.getValue();
-          if (data?.objects?.length) {
-            const { id } = data.objects[0];
-            const conversation = await core.services.conversationLoad.load(id);
-            if (conversation) {
-              chatStateDispatch({
-                type: 'receive',
-                payload: {
-                  messages: conversation.messages,
-                  interactions: conversation.interactions,
-                },
-              });
-            }
+      core.services.conversationLoad.getLatestConversationId().then(async (conversationId) => {
+        if (conversationId) {
+          const conversation = await core.services.conversationLoad.load(conversationId);
+          if (conversation) {
+            chatStateDispatch({
+              type: 'receive',
+              payload: {
+                messages: conversation.messages,
+                interactions: conversation.interactions,
+              },
+            });
           }
-        });
+        }
+      });
     }
-  }, [chatStateDispatch]);
+  }, [chatStateDispatch, core.services.conversationLoad]);
 
   return (
     <>


### PR DESCRIPTION
### Description
Add standalone conversations service to conversation load to avoid chat page show loading screen during history page loading new conversations:

- Before
 

https://github.com/user-attachments/assets/bbf4f419-9335-4294-a687-bc4996924a4d


- After

https://github.com/user-attachments/assets/70d86880-5103-4de5-8413-d7afb8346348


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
