### PR TITLE
Enhance chatbot message top-scrolling in full screen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 - Support log pattern in discover summary ([#550](https://github.com/opensearch-project/dashboards-assistant/pull/550))
 
+- Buffer for special characters ([#549](https://github.com/opensearch-project/dashboards-assistant/pull/549))
+- Save chatbot flyout visualize state to local storage ([#553](https://github.com/opensearch-project/dashboards-assistant/pull/553))
+- T2viz supports reading time range from context ([#557](https://github.com/opensearch-project/dashboards-assistant/pull/557/))
+- Prevent user from navigating to t2viz from discover if ppl return no results/error ([#546](https://github.com/opensearch-project/dashboards-assistant/pull/546))
+- Improve the chatbot UX by scroll the user input message to the top after sending ([#545](https://github.com/opensearch-project/dashboards-assistant/pull/545))
+- Add format instruction for alert summary ([#568](https://github.com/opensearch-project/dashboards-assistant/pull/568))
+- Add the admin UI setting option for control all dashboard assistant features ([#578](https://github.com/opensearch-project/dashboards-assistant/pull/578))
+- Enhance chatbot message top-scrolling in full screen mode ([#576](https://github.com/opensearch-project/dashboards-assistant/pull/576))
+
 ### Bug Fixes
 - detect serverless data source ([#627](https://github.com/opensearch-project/dashboards-assistant/pull/627))
 

--- a/public/chat_flyout.tsx
+++ b/public/chat_flyout.tsx
@@ -23,6 +23,7 @@ interface ChatFlyoutProps {
 export const ChatFlyout = (props: ChatFlyoutProps) => {
   const chatContext = useChatContext();
   const chatHistoryPageLoadedRef = useRef(false);
+  const chatFlyOutRef = useRef<HTMLDivElement>(null);
 
   let chatPageVisible = false;
   let chatHistoryPageVisible = false;
@@ -89,6 +90,7 @@ export const ChatFlyout = (props: ChatFlyoutProps) => {
         },
         { 'llm-chatbot-border-top': sidecarDockedMode === SIDECAR_DOCKED_MODE.TAKEOVER }
       )}
+      ref={chatFlyOutRef}
     >
       <>
         <div className={cs('llm-chat-flyout-header')}>
@@ -109,7 +111,7 @@ export const ChatFlyout = (props: ChatFlyoutProps) => {
                 initialSize={resizable ? 70 : undefined}
                 paddingSize="none"
               >
-                <ChatPage />
+                <ChatPage chatFlyoutRef={chatFlyOutRef} />
               </Panel>
               <>
                 {resizable && <Resizer />}

--- a/public/tabs/chat/chat_page.test.tsx
+++ b/public/tabs/chat/chat_page.test.tsx
@@ -37,6 +37,10 @@ jest.mock('./chat_page_content', () => {
   };
 });
 
+const mockChatFlyoutRef = {
+  current: document.createElement('div'),
+} as React.RefObject<HTMLDivElement>;
+
 describe('<ChatPage />', () => {
   const dispatchMock = jest.fn();
   const loadMock = jest.fn().mockResolvedValue({
@@ -82,7 +86,7 @@ describe('<ChatPage />', () => {
   });
 
   it('should reload the current conversation when user click refresh', async () => {
-    render(<ChatPage />);
+    render(<ChatPage chatFlyoutRef={mockChatFlyoutRef} />);
     fireEvent.click(screen.getByText('refresh'));
 
     expect(loadMock).toHaveBeenCalledWith('mocked_conversation_id');
@@ -99,7 +103,7 @@ describe('<ChatPage />', () => {
       conversationId: undefined,
       chatEnabled: true,
     });
-    render(<ChatPage />);
+    render(<ChatPage chatFlyoutRef={mockChatFlyoutRef} />);
     fireEvent.click(screen.getByText('refresh'));
 
     expect(loadMock).not.toHaveBeenCalled();
@@ -127,7 +131,7 @@ describe('<ChatPage />', () => {
       interactions: [],
     });
 
-    render(<ChatPage />);
+    render(<ChatPage chatFlyoutRef={mockChatFlyoutRef} />);
 
     fireEvent.click(screen.getByText('Refresh conversations list'));
 

--- a/public/tabs/chat/chat_page.tsx
+++ b/public/tabs/chat/chat_page.tsx
@@ -4,7 +4,7 @@
  */
 
 import { EuiFlyoutBody, EuiFlyoutFooter, EuiPage, EuiPageBody, EuiSpacer } from '@elastic/eui';
-import React, { useCallback, useRef } from 'react';
+import React, { RefObject, useCallback, useRef } from 'react';
 import cs from 'classnames';
 import { useObservable } from 'react-use';
 import { useChatContext, useCore } from '../../contexts';
@@ -14,6 +14,7 @@ import { ChatInputControls } from './controls/chat_input_controls';
 
 interface ChatPageProps {
   className?: string;
+  chatFlyoutRef: RefObject<HTMLDivElement>;
 }
 
 export const ChatPage: React.FC<ChatPageProps> = (props) => {
@@ -51,13 +52,14 @@ export const ChatPage: React.FC<ChatPageProps> = (props) => {
   const { loadChat } = useChatActions();
   const chatScrollTopRef = useRef<{ scrollTop: number; height: number } | null>(null);
   const handleScroll = async (event: React.UIEvent<HTMLElement>) => {
-    const scrollTop = event.target.scrollTop;
+    const scrollTop = (event.target as HTMLElement).scrollTop;
     if (!messagesLoading && chatState?.nextToken && chatState?.nextToken !== '') {
       if (scrollTop < 150) {
         const html = event.target;
-        chatScrollTopRef.current = { scrollTop, height: html.scrollHeight };
+        chatScrollTopRef.current = { scrollTop, height: (html as HTMLElement).scrollHeight };
         await loadChat(chatContext.conversationId, chatState.nextToken);
-        html.scrollTop = html.scrollHeight - chatScrollTopRef.current.height;
+        (html as HTMLElement).scrollTop =
+          (html as HTMLElement).scrollHeight - chatScrollTopRef.current.height;
         chatScrollTopRef.current = null;
       }
     }
@@ -90,6 +92,7 @@ export const ChatPage: React.FC<ChatPageProps> = (props) => {
         <EuiPage paddingSize="s">
           <EuiPageBody component="div">
             <ChatPageContent
+              chatFlyoutRef={props.chatFlyoutRef}
               messagesLoading={messagesLoading}
               conversationsLoading={conversationsLoading}
               messagesLoadingError={

--- a/public/tabs/chat/chat_page_content.test.tsx
+++ b/public/tabs/chat/chat_page_content.test.tsx
@@ -49,6 +49,10 @@ const mockChatScrollTopRef = {
   },
 };
 
+const mockChatFlyoutRef = {
+  current: document.createElement('div'),
+} as React.RefObject<HTMLDivElement>;
+
 describe('<ChatPageContent />', () => {
   const abortActionMock = jest.fn();
   const executeActionMock = jest.fn();
@@ -99,6 +103,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryAllByLabelText('chat message bubble')).toHaveLength(1);
@@ -113,6 +118,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryAllByLabelText('chat suggestions')).toHaveLength(1);
@@ -144,6 +150,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryAllByLabelText('chat message bubble')).toHaveLength(3);
@@ -185,6 +192,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryAllByLabelText('chat suggestions')).toHaveLength(1);
@@ -216,6 +224,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryAllByLabelText('chat suggestions')).toHaveLength(0);
@@ -251,6 +260,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryAllByLabelText('chat suggestions')).toHaveLength(0);
@@ -264,6 +274,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryByText('Loading conversation')).toBeInTheDocument();
@@ -280,6 +291,7 @@ describe('<ChatPageContent />', () => {
         messagesLoadingError={new Error('failed to get response')}
         onRefreshConversation={onRefreshMock}
         onRefreshConversationsList={onRefreshMock}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryByText('failed to get response')).toBeInTheDocument();
@@ -301,6 +313,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(screen.queryByText('Stop generating response')).toBeInTheDocument();
@@ -316,6 +329,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     fireEvent.click(screen.getByText('What are the indices in my cluster?'));
@@ -357,6 +371,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
     expect(queryAllByTestId(`showRegenerate-false`).length).toEqual(2);
@@ -383,6 +398,7 @@ describe('<ChatPageContent />', () => {
         chatScrollTopRef={mockChatScrollTopRef}
         onRefreshConversation={jest.fn()}
         onRefreshConversationsList={jest.fn()}
+        chatFlyoutRef={mockChatFlyoutRef}
       />
     );
 

--- a/public/tabs/chat/chat_page_content.tsx
+++ b/public/tabs/chat/chat_page_content.tsx
@@ -13,7 +13,7 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
-import React, { ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { RefObject, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { IMessage, Interaction } from '../../../common/types/chat_saved_object_attributes';
 import { WelcomeMessage } from '../../components/chat_welcome_message';
 import { useChatContext } from '../../contexts';
@@ -28,6 +28,7 @@ import { LLMResponseType } from '../../hooks/use_chat_state';
 import { LoadingPlaceholder } from './loading_placeholder';
 
 interface ChatPageContentProps {
+  chatFlyoutRef: RefObject<HTMLDivElement>;
   messagesLoading: boolean;
   conversationsLoading: boolean;
   messagesLoadingError?: Error;
@@ -57,9 +58,11 @@ export const ChatPageContent: React.FC<ChatPageContentProps> = React.memo((props
   const [messageSpacerHeight, setMessageSpacerHeight] = useState(0);
 
   useLayoutEffect(() => {
-    if (loading && latestInputRef.current) {
+    if (loading && latestInputRef.current && props.chatFlyoutRef.current) {
       setMessageSpacerHeight(
-        window.innerHeight - latestInputRef.current.clientHeight - CHAT_PAGE_CONTENT_PADDING_HEIGHT
+        props.chatFlyoutRef.current?.clientHeight! -
+          latestInputRef.current.clientHeight -
+          CHAT_PAGE_CONTENT_PADDING_HEIGHT
       );
 
       requestAnimationFrame(() => {
@@ -71,7 +74,7 @@ export const ChatPageContent: React.FC<ChatPageContentProps> = React.memo((props
         }
       });
     }
-  }, [loading, window.innerHeight]);
+  }, [loading, props.chatFlyoutRef]);
 
   useEffect(() => {
     // Always clear the height when reopen the chat window or load new chat


### PR DESCRIPTION
### Description

Calculate the height of user's input message scrolling base on the actual chatbot flyout height instead of window height, improve the behavior for chatbot in full screen mode.

Before:

https://github.com/user-attachments/assets/aee94a96-f09b-4f39-acbc-407e5a03aae2

After:

https://github.com/user-attachments/assets/7f4c0f23-17cb-4732-ab2e-0677979f71aa



### Issues Resolved
NA

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
