### PR TITLE
Generative dashboard: Jump to a dedicated page after click "data insights" button

### DIFF
--- a/common/constants/llm.ts
+++ b/common/constants/llm.ts
@@ -22,6 +22,7 @@ export const ASSISTANT_API = {
 export const TEXT2VIZ_API = {
   TEXT2PPL: `${API_BASE}/text2ppl`,
   TEXT2VEGA: `${API_BASE}/text2vega`,
+  DATA_INSIGHTS: `${API_BASE}/data_insights`,
 };
 
 export const AGENT_API = {
@@ -47,3 +48,4 @@ export const TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID = 'os_text2vega';
 export const TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID = 'os_text2vega_with_instructions';
 export const TEXT2PPL_AGENT_CONFIG_ID = 'os_query_assist_ppl';
 export const DATA2SUMMARY_AGENT_CONFIG_ID = 'os_data2summary';
+export const TEXT2DASHBOARD_AGENT_CONFIG_ID = 'os_text2dashboard_sonnet';

--- a/public/components/text_to_dashboard/checkable_data_list.tsx
+++ b/public/components/text_to_dashboard/checkable_data_list.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiCheckableCard,
+  EuiFormFieldset,
+  EuiSpacer,
+  EuiTitle,
+  htmlIdGenerator,
+} from '@elastic/eui';
+import React from 'react';
+
+interface Props {
+  title: string;
+  items: string[];
+  selection: string[];
+  onToggle: (item: string) => void;
+}
+
+export const CheckableDataList = (props: Props) => {
+  return (
+    <div>
+      <EuiFormFieldset
+        legend={{
+          children: (
+            <EuiTitle size="xs">
+              <span>{props.title}</span>
+            </EuiTitle>
+          ),
+        }}
+      >
+        {props.items.map((item) => (
+          <>
+            <EuiCheckableCard
+              id={htmlIdGenerator()()}
+              label={item}
+              checkableType="checkbox"
+              value={item}
+              checked={props.selection.includes(item)}
+              onChange={() => props.onToggle(item)}
+            />
+            <EuiSpacer size="m" />
+          </>
+        ))}
+      </EuiFormFieldset>
+    </div>
+  );
+};

--- a/public/components/text_to_dashboard/create_dashboard.ts
+++ b/public/components/text_to_dashboard/create_dashboard.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import uuid from 'uuid';
+
+import { getDashboard, getDashboardVersion } from '../../services';
+import { DashboardUrlGeneratorState } from '../../../../../src/plugins/dashboard/public/url_generator';
+import { setStateToOsdUrl } from '../../../../../src/plugins/opensearch_dashboards_utils/public';
+
+interface PanelConfig {
+  id: string;
+  version: string;
+  type: string;
+  panelIndex: string;
+  gridData: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    i: string;
+  };
+}
+
+export const createDashboard = async (objects: Array<{ id: string; type: string }>) => {
+  const dashboardService = getDashboard();
+  const loader = dashboardService.getSavedDashboardLoader();
+  const dashboard = await loader.get();
+  const panels: PanelConfig[] = [];
+  const { version } = getDashboardVersion();
+
+  const PANEL_WIDTH = 24;
+  const PANEL_HEIGHT = 15;
+  let x = 0;
+  let y = 0;
+  for (const obj of objects) {
+    const panelIndex = uuid.v4();
+    panels.push({
+      version,
+      id: obj.id,
+      type: obj.type,
+      panelIndex,
+      gridData: {
+        i: panelIndex,
+        x,
+        y,
+        w: PANEL_WIDTH,
+        h: PANEL_HEIGHT,
+      },
+    });
+    x = x + PANEL_WIDTH;
+
+    if (x >= 48) {
+      x = 0;
+      y = y + PANEL_HEIGHT;
+    }
+  }
+
+  dashboard.panelsJSON = JSON.stringify(panels);
+  dashboard.title = `[AI Generated] - ${uuid.v4()}`;
+  dashboard.description = 'The dashboard was created by OpenSearch dashboard assistant';
+
+  const dashboardUrlGenerator = dashboardService.dashboardUrlGenerator;
+  const state: DashboardUrlGeneratorState = {};
+  const dashboardUrl = await dashboardUrlGenerator?.createUrl(state);
+  if (!dashboardUrl) {
+    throw new Error('Failed to generate dashboard URL');
+  }
+
+  const appState = {
+    panels: panels.map((panel) => ({
+      embeddableConfig: {},
+      gridData: {
+        h: panel.gridData.h,
+        i: panel.gridData.i,
+        w: panel.gridData.w,
+        x: panel.gridData.x,
+        y: panel.gridData.y,
+      },
+      id: panel.id,
+      panelIndex: panel.panelIndex,
+      type: panel.type,
+      version: panel.version,
+    })),
+  };
+
+  const finalUrl = setStateToOsdUrl('_a', appState, { useHash: true }, dashboardUrl);
+  dashboard.url = finalUrl;
+
+  return dashboard;
+};

--- a/public/components/text_to_dashboard/input_panel.tsx
+++ b/public/components/text_to_dashboard/input_panel.tsx
@@ -1,0 +1,472 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Subscription } from 'rxjs';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiCommentList,
+  EuiCommentProps,
+  EuiEmptyPrompt,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiLink,
+  EuiLoadingContent,
+  EuiLoadingLogo,
+  EuiPage,
+  EuiPageBody,
+  EuiProgress,
+  EuiText,
+  EuiBreadcrumb,
+  EuiHeaderLinks,
+  EuiButtonIcon,
+  EuiSpacer,
+  EuiPanel,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { useLocation } from 'react-router-dom';
+import { CoreStart, HeaderVariant } from '../../../../../src/core/public';
+import { DataPublicPluginStart, IndexPattern } from '../../../../../src/plugins/data/public';
+import { Pipeline } from '../../utils/pipeline/pipeline';
+import { PPLSampleTask } from '../../utils/pipeline/ppl_sample_task';
+import { DataInsightsTask } from '../../utils/pipeline/data_insights_task';
+import { CheckableDataList } from './checkable_data_list';
+import { Text2PPLTask } from '../../utils/pipeline/text_to_ppl_task';
+import { Text2VegaTask } from '../../utils/pipeline/text_to_vega_task';
+import { getVisNLQSavedObjectLoader } from '../../vis_nlq/saved_object_loader';
+import { VisNLQSavedObject } from '../../vis_nlq/types';
+import { createDashboard } from './create_dashboard';
+import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { MountPointPortal } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { StartServices } from '../../types';
+import { SourceSelector } from '../visualization/source_selector';
+
+type Status = 'INSIGHTS_LOADING' | 'INSIGHTS_LOADED' | 'DASHBOARDS_CREATING' | 'DASHBOARDS_CREATED';
+
+export const InputPanel = () => {
+  const {
+    services: {
+      application,
+      chrome,
+      notifications,
+      data,
+      http,
+      uiSettings,
+      savedObjects,
+      setHeaderActionMenu,
+    },
+  } = useOpenSearchDashboards<StartServices>();
+  const { search } = useLocation();
+  const searchParams = new URLSearchParams(search);
+  const indexPatternId = searchParams.get('indexPatternId') || '';
+  const dataSourceId = searchParams.get('dataSourceId');
+  const [indexPattern, setIndexPattern] = useState<IndexPattern | null>(null);
+  const [dataInsights, setDataInsights] = useState<Record<string, string[]>>({});
+  const [selectedInsights, setSelectedInsights] = useState<string[]>([]);
+  const [updateMessages, setUpdateMessages] = useState<EuiCommentProps[]>([]);
+  const [panelStatus, setPanelStatus] = useState<Status>('INSIGHTS_LOADING');
+  const dataInsightsPipeline = useRef<Pipeline | null>(null);
+  const useUpdatedUX = uiSettings.get('home:useNewHomePage');
+
+  // Load index pattern from URL parameter
+  useEffect(() => {
+    if (indexPatternId) {
+      data.indexPatterns
+        .get(indexPatternId)
+        .then((pattern) => {
+          setIndexPattern(pattern);
+        })
+        .catch((e) => {
+          console.error('Failed to load index pattern:', e);
+          notifications.toasts.addDanger({
+            title: i18n.translate('dashboardAssistant.feature.text2dash.loadFailed', {
+              defaultMessage: 'Failed to load index pattern: {id}',
+              values: { id: indexPatternId },
+            }),
+          });
+        });
+    }
+  }, [indexPatternId, data.indexPatterns, notifications]);
+
+  if (dataInsightsPipeline.current === null && indexPattern) {
+    dataInsightsPipeline.current = new Pipeline([
+      new PPLSampleTask(data.search),
+      new DataInsightsTask(http),
+    ]);
+  }
+
+  useEffect(() => {
+    let subscription: Subscription;
+    if (dataInsightsPipeline.current) {
+      subscription = dataInsightsPipeline.current.status$.subscribe({
+        next: (status) => {
+          setPanelStatus(status === 'RUNNING' ? 'INSIGHTS_LOADING' : 'INSIGHTS_LOADED');
+        },
+        error: (err) => {
+          setPanelStatus('INSIGHTS_LOADED');
+          notifications.toasts.addDanger({
+            title: 'Failed to generate insights',
+            text: err.message || 'An error occurred while generating insights',
+          });
+        },
+        complete: () => {
+          console.log('Pipeline status$ completed');
+        },
+      });
+    }
+    return () => {
+      if (subscription) {
+        subscription.unsubscribe();
+      }
+    };
+  }, [indexPattern]);
+
+  useEffect(() => {
+    let subscription: Subscription;
+    if (dataInsightsPipeline.current) {
+      subscription = dataInsightsPipeline.current.output$.subscribe({
+        next: (output) => {
+          setDataInsights(output.dataInsights);
+        },
+        error: (err) => {
+          notifications.toasts.addDanger({
+            title: 'Failed to generate insights',
+            text: err.message || 'An error occurred while generating insights',
+          });
+        },
+        complete: () => {
+          console.log('Pipeline output$ completed');
+        },
+      });
+    }
+    return () => {
+      if (subscription) {
+        subscription.unsubscribe();
+      }
+    };
+  }, [indexPattern]);
+
+  useEffect(() => {
+    if (dataInsightsPipeline.current && indexPattern) {
+      dataInsightsPipeline.current.run({
+        ppl: `source=${indexPattern.getIndex()}`,
+        dataSourceId,
+      });
+    }
+  }, [indexPattern, dataSourceId]);
+
+  const onToggle = useCallback(
+    (item: string) => {
+      const selection = new Set(selectedInsights);
+      if (selection.has(item)) {
+        selection.delete(item);
+      } else {
+        selection.add(item);
+      }
+      setSelectedInsights([...selection]);
+    },
+    [selectedInsights]
+  );
+
+  const onGenerate = useCallback(async () => {
+    if (!indexPattern) return;
+    setPanelStatus('DASHBOARDS_CREATING');
+    setUpdateMessages([
+      {
+        username: 'Dashboards assistant',
+        event: 'started to create visualization',
+        type: 'update',
+        timelineIcon: 'sparkleFilled',
+      },
+    ]);
+    const visualizations: Array<{ id: string; type: string }> = [];
+
+    for (const insight of selectedInsights) {
+      const pipeline = new Pipeline([
+        new Text2PPLTask(http),
+        new PPLSampleTask(data.search),
+        new Text2VegaTask(http, savedObjects),
+      ]);
+      try {
+        const [inputQuestion, inputInstruction] = insight.split('//');
+        // generate vega spec
+        // TODO: validate output.vega presence
+        const output = await pipeline.runOnce({
+          index: indexPattern.getIndex(),
+          inputQuestion,
+          inputInstruction,
+          dataSourceId,
+        });
+        const visTitle = output?.vega?.title;
+        const visDescription = output?.vega?.description;
+        // saved visualization
+        const loader = getVisNLQSavedObjectLoader();
+        const savedVis: VisNLQSavedObject = await loader.get();
+        savedVis.visualizationState = JSON.stringify({
+          title: visTitle,
+          type: 'vega-lite',
+          params: {
+            spec: output?.vega,
+          },
+        });
+        savedVis.uiState = JSON.stringify({
+          input: inputQuestion,
+          instruction: inputInstruction,
+        });
+        savedVis.searchSourceFields = { index: indexPattern };
+        savedVis.title = visTitle;
+        savedVis.description = visDescription;
+        const id = await savedVis.save({});
+        visualizations.push({ id, type: 'visualization-nlq' });
+
+        const url = application.getUrlForApp('text2viz', {
+          path: `edit/${id}`,
+        });
+
+        setUpdateMessages((messages) => [
+          ...messages,
+          {
+            username: 'Dashboards assistant',
+            event: (
+              <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiText>created visualization</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="success">success</EuiBadge>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            ),
+            type: 'update',
+            children: (
+              <EuiText size="s">
+                <p>
+                  {insight}{' '}
+                  <EuiLink href={url} target="_blank">
+                    view
+                  </EuiLink>
+                </p>
+              </EuiText>
+            ),
+            timelineIcon: 'check',
+          },
+        ]);
+      } catch (e) {
+        setUpdateMessages((messages) => [
+          ...messages,
+          {
+            username: 'Dashboards assistant',
+            event: (
+              <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiText>created visualization</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiBadge color="danger">fail</EuiBadge>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            ),
+            children: (
+              <EuiText size="s">
+                <p>{insight}</p>
+              </EuiText>
+            ),
+            timelineIcon: 'cross',
+          },
+        ]);
+      }
+    }
+
+    try {
+      // create dashboard
+      const dashboard = await createDashboard(visualizations);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      application.navigateToUrl(dashboard.url);
+    } catch (e) {
+      setUpdateMessages((messages) => [
+        ...messages,
+        {
+          username: 'Dashboards assistant',
+          event: (
+            <EuiFlexGroup responsive={false} alignItems="center" gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiText>created dashboard</EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiBadge color="danger">fail</EuiBadge>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ),
+          type: 'update',
+          timelineIcon: 'cross',
+        },
+      ]);
+    }
+
+    setPanelStatus('DASHBOARDS_CREATED');
+  }, [http, savedObjects, data, selectedInsights, dataSourceId, indexPattern, application]);
+
+  // Set breadcrumbs
+  useEffect(() => {
+    // const useUpdatedUX = uiSettings.get('home:useNewHomePage');
+    const pageTitle = i18n.translate('dashboardAssistant.feature.text2dash.title', {
+      defaultMessage: 'New Dashboard',
+    });
+    const breadcrumbs: EuiBreadcrumb[] = [
+      {
+        text: i18n.translate('dashboardAssistant.feature.text2dash.breadcrumbs.dashboards', {
+          defaultMessage: 'Dashboards',
+        }),
+        onClick: () => {
+          application.navigateToApp('dashboards');
+        },
+      },
+    ];
+    if (!useUpdatedUX) {
+      breadcrumbs.push({
+        text: pageTitle,
+      });
+    }
+    chrome.setBreadcrumbs(breadcrumbs);
+  }, [chrome, application, uiSettings]);
+
+  useEffect(() => {
+    chrome.setHeaderVariant(HeaderVariant.APPLICATION);
+    return () => {
+      chrome.setHeaderVariant();
+    };
+  }, [chrome]);
+
+  const getInputSection = () => {
+    return (
+      <>
+        <EuiFlexGroup alignItems="center" gutterSize="s">
+          <EuiFlexItem grow={2} style={{ width: 0 }}>
+            <SourceSelector
+              selectedSourceId={indexPatternId}
+              onChange={(ds) => {
+                const newParams = new URLSearchParams(search);
+                newParams.set('indexPatternId', ds.value);
+                application.navigateToUrl(
+                  application.getUrlForApp('dashboards', {
+                    path: `/text2dash?${newParams.toString()}`,
+                  })
+                );
+              }}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </>
+    );
+  };
+
+  if (!indexPattern) {
+    return (
+      <EuiPage>
+        <EuiPageBody>
+          <EuiEmptyPrompt
+            iconType="alert"
+            iconColor="danger"
+            title={<h2>Index Pattern Not Found</h2>}
+            body={
+              <EuiText size="s">
+                <p>Unable to load the specified index pattern.</p>
+              </EuiText>
+            }
+          />
+        </EuiPageBody>
+      </EuiPage>
+    );
+  }
+
+  return (
+    <EuiPage className="text2dash__page" direction="column">
+      <MountPointPortal setMountPoint={setHeaderActionMenu}>
+        <EuiFlexGroup alignItems="center" gutterSize="s" style={{ flexGrow: 0, paddingTop: '4px' }}>
+          <EuiHeaderLinks data-test-subj="text2dash-top-nav">
+            {/* {useUpdatedUX && ( */}
+            <EuiText size="s">
+              {i18n.translate('dashboardAssistant.feature.text2dash.title', {
+                defaultMessage: 'New Dashboard',
+              })}
+            </EuiText>
+            {/* )} */}
+            {/* <EuiButtonIcon
+              title={i18n.translate('dashboardAssistant.feature.text2dash.generate', {
+                defaultMessage: 'Generate dashboard',
+              })}
+              aria-label="generate"
+              display="base"
+              iconType="save"
+              size="s"
+              color={useUpdatedUX ? 'text' : 'primary'}
+              onClick={onGenerate}
+              isDisabled={
+                selectedInsights.length === 0 ||
+                !indexPattern ||
+                panelStatus === 'DASHBOARDS_CREATING'
+              }
+            /> */}
+          </EuiHeaderLinks>
+          {/* {useUpdatedUX && */}
+          {getInputSection()}
+          {/* } */}
+        </EuiFlexGroup>
+      </MountPointPortal>
+      {!useUpdatedUX && (
+        <>
+          <EuiFlexGroup alignItems="center" gutterSize="s" style={{ flexGrow: 0 }}>
+            {getInputSection()}
+          </EuiFlexGroup>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      <EuiPageBody>
+        {panelStatus === 'INSIGHTS_LOADING' && (
+          <EuiEmptyPrompt
+            icon={<EuiLoadingLogo logo="visPie" size="xl" />}
+            title={<h2>Generating Insights</h2>}
+          />
+        )}
+        {panelStatus === 'INSIGHTS_LOADED' && (
+          <>
+            {Object.keys(dataInsights).map((key) => (
+              <CheckableDataList
+                key={key}
+                title={key}
+                items={dataInsights[key]}
+                selection={selectedInsights}
+                onToggle={onToggle}
+              />
+            ))}
+          </>
+        )}
+        {(panelStatus === 'DASHBOARDS_CREATING' || panelStatus === 'DASHBOARDS_CREATED') && (
+          <EuiCommentList comments={updateMessages} />
+        )}
+        {panelStatus === 'DASHBOARDS_CREATING' && <EuiLoadingContent lines={2} />}
+        {panelStatus === 'DASHBOARDS_CREATING' && <EuiProgress size="xs" color="accent" />}
+        {panelStatus !== 'INSIGHTS_LOADING' && (
+          <>
+            <EuiFlexGroup justifyContent="flexEnd">
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  fill
+                  onClick={onGenerate}
+                  isLoading={panelStatus === 'DASHBOARDS_CREATING'}
+                  isDisabled={selectedInsights.length === 0 || !indexPattern}
+                >
+                  Generate dashboard
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </>
+        )}
+      </EuiPageBody>
+    </EuiPage>
+  );
+};

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -45,6 +45,8 @@ import {
   setExpressions,
   setHttp,
   setAssistantService,
+  setDashboard,
+  setDashboardVersion,
   setTimeFilter,
   setLocalStorage,
 } from './services';
@@ -62,6 +64,7 @@ import { AssistantService } from './services/assistant_service';
 import { ActionContextMenu } from './components/ui_action_context_menu';
 import { AI_ASSISTANT_QUERY_EDITOR_TRIGGER, bootstrap } from './ui_triggers';
 import { TEXT2VIZ_APP_ID } from './text2viz';
+import { TEXT2DASH_APP_ID } from './text2dash';
 import { VIS_NLQ_APP_ID, VIS_NLQ_SAVED_OBJECT } from '../common/constants/vis_type_nlq';
 import {
   createVisNLQSavedObjectLoader,
@@ -74,6 +77,7 @@ import {
   INDEX_PATTERN_URL_SEARCH_KEY,
 } from './components/visualization/text2viz';
 import { DEFAULT_DATA, createStorage } from '../../../src/plugins/data/common';
+import { registerGenerateDashboardUIAction } from './ui_actions';
 
 export const [getCoreStart, setCoreStart] = createGetterSetter<CoreStart>('CoreStart');
 
@@ -104,7 +108,7 @@ export class AssistantPlugin
   private resetChatSubscription: Subscription | undefined;
   private assistantService = new AssistantService();
 
-  constructor(initializerContext: PluginInitializerContext) {
+  constructor(private initializerContext: PluginInitializerContext) {
     this.config = initializerContext.config.get<ConfigSchema>();
     this.dataSourceService = new DataSourceService();
   }
@@ -223,6 +227,36 @@ export class AssistantPlugin
             };
           } else {
             const { renderAppNotFound } = await import('./text2viz');
+            return renderAppNotFound(params);
+          }
+        },
+      });
+
+      core.application.register({
+        id: TEXT2DASH_APP_ID,
+        title: i18n.translate('dashboardAssistant.feature.text2dash', {
+          defaultMessage: 'Data Insights Dashboard',
+        }),
+        navLinkStatus: AppNavLinkStatus.hidden,
+        mount: async (params: AppMountParameters) => {
+          const [coreStart, pluginsStart] = await core.getStartServices();
+          const assistantEnabled = coreStart.application.capabilities?.assistant?.enabled === true;
+          if (assistantEnabled) {
+            params.element.classList.add('text2dash-wrapper');
+            const { renderText2DashApp } = await import('./text2dash');
+            const unmount = renderText2DashApp(params, {
+              ...pluginsStart,
+              ...coreStart,
+              setHeaderActionMenu: params.setHeaderActionMenu,
+              config: this.config,
+            });
+
+            return () => {
+              unmount();
+              params.element.classList.remove('text2dash-wrapper');
+            };
+          } else {
+            const { renderAppNotFound } = await import('./text2dash');
             return renderAppNotFound(params);
           }
         },
@@ -375,7 +409,7 @@ export class AssistantPlugin
 
   public start(
     core: CoreStart,
-    { data, expressions, uiActions }: AssistantPluginStartDependencies
+    { data, expressions, uiActions, dashboard }: AssistantPluginStartDependencies
   ): AssistantStart {
     const assistantServiceStart = this.assistantService.start(core.http);
     setCoreStart(core);
@@ -384,6 +418,7 @@ export class AssistantPlugin
     setConfigSchema(this.config);
     setUiActions(uiActions);
     setAssistantService(assistantServiceStart);
+    setDashboard(dashboard);
     setLocalStorage(createStorage({ engine: window.localStorage, prefix: 'dashboardsAssistant.' }));
 
     if (this.config.text2viz.enabled) {
@@ -456,6 +491,17 @@ export class AssistantPlugin
         overlays: core.overlays,
       });
       setVisNLQSavedObjectLoader(savedVisNLQLoader);
+
+      registerGenerateDashboardUIAction({
+        core,
+        data,
+        uiActions,
+        assistantService: assistantServiceStart,
+      });
+
+      const opensearchDashboardsVersion = this.initializerContext.env.packageInfo.version;
+
+      setDashboardVersion({ version: opensearchDashboardsVersion });
     }
 
     setIndexPatterns(data.indexPatterns);

--- a/public/services/index.ts
+++ b/public/services/index.ts
@@ -13,6 +13,7 @@ import { IndexPatternsContract, TimefilterContract } from '../../../../src/plugi
 import { ExpressionsStart } from '../../../../src/plugins/expressions/public';
 import { AssistantServiceStart } from './assistant_service';
 import chatIcon from '../assets/chat.svg';
+import { DashboardStart } from '../../../../src/plugins/dashboard/public';
 
 export * from './incontext_insight';
 export { ConversationLoadService } from './conversation_load_service';
@@ -53,3 +54,8 @@ export { DataSourceService, DataSourceServiceContract } from './data_source_serv
 export const getLogoIcon = (type: 'gray' | 'gradient' | 'white', defaultIcon = chatIcon) => {
   return getConfigSchema()?.branding?.logo?.[type] ?? defaultIcon;
 };
+
+export const [getDashboard, setDashboard] = createGetterSetter<DashboardStart>('Dashboard');
+export const [getDashboardVersion, setDashboardVersion] = createGetterSetter<{ version: string }>(
+  'DashboardVersion'
+);

--- a/public/text2dash.tsx
+++ b/public/text2dash.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Route, Router, Switch } from 'react-router-dom';
+import { EuiEmptyPrompt, EuiPage, EuiPageBody, EuiPageContent, EuiText } from '@elastic/eui';
+import { AppMountParameters } from '../../../src/core/public';
+import { InputPanel } from './components/text_to_dashboard/input_panel';
+import { OpenSearchDashboardsContextProvider } from '../../../src/plugins/opensearch_dashboards_react/public';
+import { StartServices } from './types';
+
+export const TEXT2DASH_APP_ID = 'text2dash';
+
+export const renderText2DashApp = (params: AppMountParameters, services: StartServices) => {
+  ReactDOM.render(
+    <OpenSearchDashboardsContextProvider services={services}>
+      <Router history={params.history}>
+        <Switch>
+          <Route path={['/']} component={InputPanel} />
+        </Switch>
+      </Router>
+    </OpenSearchDashboardsContextProvider>,
+    params.element
+  );
+  return () => {
+    ReactDOM.unmountComponentAtNode(params.element);
+  };
+};
+
+export const renderAppNotFound = (params: AppMountParameters) => {
+  ReactDOM.render(
+    <EuiPage style={{ minHeight: '100%' }} data-test-subj="appNotFoundPageContent">
+      <EuiPageBody component="main">
+        <EuiPageContent verticalPosition="center" horizontalPosition="center">
+          <EuiEmptyPrompt
+            iconType="alert"
+            iconColor="danger"
+            title={<h2>Application Not Found</h2>}
+            body={
+              <EuiText size="s">
+                <p>
+                  No application was found at this URL. Please check your app status to enable this
+                  feature.
+                </p>
+              </EuiText>
+            }
+          />
+        </EuiPageContent>
+      </EuiPageBody>
+    </EuiPage>,
+    params.element
+  );
+  return () => {
+    ReactDOM.unmountComponentAtNode(params.element);
+  };
+};

--- a/public/ui_actions.tsx
+++ b/public/ui_actions.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  TEXT2PPL_AGENT_CONFIG_ID,
+  TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID,
+  TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID,
+} from '../common/constants/llm';
+import { DEFAULT_DATA } from '../../../src/plugins/data/common';
+import { UiActionsStart } from '../../../src/plugins/ui_actions/public';
+import { AssistantServiceStart } from './services/assistant_service';
+import { AI_ASSISTANT_QUERY_EDITOR_TRIGGER } from './ui_triggers';
+import { CoreStart } from '../../../src/core/public';
+import { DataPublicPluginStart } from '../../../src/plugins/data/public';
+import { TEXT2DASH_APP_ID } from './text2dash';
+
+interface Services {
+  core: CoreStart;
+  data: DataPublicPluginStart;
+  uiActions: UiActionsStart;
+  assistantService: AssistantServiceStart;
+}
+
+export function registerGenerateDashboardUIAction(services: Services) {
+  services.uiActions.addTriggerAction(AI_ASSISTANT_QUERY_EDITOR_TRIGGER, {
+    id: 'assistant_generate_dashboard_action',
+    order: 10,
+    getDisplayName: () => 'Data insights',
+    getIconType: () => 'dashboard' as const,
+    // T2Viz is only compatible with data sources that have certain agents configured
+    isCompatible: async (context) => {
+      // t2viz only supports selecting index pattern at the moment
+      if (context.datasetType === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN && context.datasetId) {
+        const res = await services.assistantService.client.agentConfigExists(
+          [
+            TEXT2VEGA_RULE_BASED_AGENT_CONFIG_ID,
+            TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID,
+            TEXT2PPL_AGENT_CONFIG_ID,
+          ],
+          {
+            dataSourceId: context.dataSourceId,
+          }
+        );
+        return res.exists;
+      }
+      return false;
+    },
+    execute: async (context) => {
+      if (context.datasetId && context.datasetType === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN) {
+        const url = new URL(
+          services.core.application.getUrlForApp(TEXT2DASH_APP_ID, {
+            absolute: true,
+            path: '/',
+          })
+        );
+        url.searchParams.set('indexPatternId', context.datasetId);
+        if (context.dataSourceId) {
+          url.searchParams.set('dataSourceId', context.dataSourceId);
+        }
+        services.core.application.navigateToUrl(url.toString());
+      }
+    },
+  });
+}

--- a/public/utils/pipeline/data_insights_task.ts
+++ b/public/utils/pipeline/data_insights_task.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpSetup } from '../../../../../src/core/public';
+import { Task } from './task';
+import { TEXT2VIZ_API } from '../../../common/constants/llm';
+
+interface Input {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sample: any;
+  dataSourceId?: string;
+}
+
+export class DataInsightsTask extends Task<Input, Input & { dataInsights: string }> {
+  http: HttpSetup;
+
+  constructor(http: HttpSetup) {
+    super();
+    this.http = http;
+  }
+
+  async execute<T extends Input>(v: T) {
+    const dataInsights: string = await this.getDataInsights(v.sample, v.dataSourceId);
+    return { ...v, dataInsights };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getDataInsights(sample: any, dataSourceId?: string) {
+    const res = await this.http.post(TEXT2VIZ_API.DATA_INSIGHTS, {
+      body: JSON.stringify({
+        sampleData: `'${JSON.stringify(sample.jsonData, undefined, 2)}'`,
+        dataSchema: `'${JSON.stringify(sample.schema, undefined, 2)}'`,
+      }),
+      query: { dataSourceId },
+    });
+    return res;
+  }
+}

--- a/server/routes/text2viz_routes.ts
+++ b/server/routes/text2viz_routes.ts
@@ -11,6 +11,7 @@ import {
   TEXT2VEGA_INPUT_SIZE_LIMIT,
   TEXT2VEGA_WITH_INSTRUCTIONS_AGENT_CONFIG_ID,
   TEXT2VIZ_API,
+  TEXT2DASHBOARD_AGENT_CONFIG_ID,
 } from '../../common/constants/llm';
 import { AssistantServiceSetup } from '../services/assistant_service';
 import { handleError } from './error_handler';
@@ -59,7 +60,7 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         let textContent = response.body.inference_results[0].output[0].result;
         // Check if the visualization is single value:
         // it should have exactly 1 metric and no dimensions.
-        let ifSingleMetric = checkSingleMetric(textContent);
+        const ifSingleMetric = checkSingleMetric(textContent);
 
         // extra content between tag <vega-lite></vega-lite>
         const startTag = '<vega-lite>';
@@ -123,6 +124,65 @@ export function registerText2VizRoutes(router: IRouter, assistantService: Assist
         return res.ok({ body: result });
       } catch (e) {
         return handleError(e, res, context.assistant_plugin.logger);
+      }
+    })
+  );
+
+  router.post(
+    {
+      path: TEXT2VIZ_API.DATA_INSIGHTS,
+      validate: {
+        body: schema.object({
+          dataSchema: schema.string(),
+          sampleData: schema.string(),
+        }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, req, res) => {
+      context.core.opensearch.client.asCurrentUser.indices.getMapping();
+      const assistantClient = assistantService.getScopedClient(req, context);
+      try {
+        const response = await assistantClient.executeAgentByConfigName(
+          TEXT2DASHBOARD_AGENT_CONFIG_ID,
+          {
+            dataSchema: req.body.dataSchema,
+            sampleData: req.body.sampleData,
+          }
+        );
+
+        let textContent = response.body.inference_results[0].output[0].result;
+
+        // extra content between tag <vega-lite></vega-lite>
+        const startTag = '<data-dimension>';
+        const endTag = '</data-dimension>';
+
+        const startIndex = textContent.indexOf(startTag);
+        const endIndex = textContent.indexOf(endTag);
+
+        if (startIndex !== -1 && endIndex !== -1 && startIndex < endIndex) {
+          // Extract the content between the tags
+          textContent = textContent.substring(startIndex + startTag.length, endIndex).trim();
+        }
+
+        return res.ok({ body: JSON.parse(textContent) });
+      } catch (e) {
+        context.assistant_plugin.logger.error('Execute agent failed!', e);
+        if (e.statusCode >= 400 && e.statusCode <= 499) {
+          return res.customError({
+            body: e.body,
+            statusCode: e.statusCode,
+            headers: e.headers,
+          });
+        } else {
+          return res.customError({
+            body: 'Execute agent failed!',
+            statusCode: 500,
+            headers: e.headers,
+          });
+        }
       }
     })
   );


### PR DESCRIPTION
### Description
This change modifies the existing functionality to transform the flyout into a dedicated page jump when the "Data Insights" button is clicked. Additionally, the generative dashboard will no longer save automatically. Instead, after generating the dashboard, users will be redirected to the dashboards page where they can edit and save their modifications independently.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
