### PR TITLE
fix: fixed failed ci due to path alias

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,8 @@
 
 // babelrc doesn't respect NODE_PATH anymore but using require does.
 // Alternative to install them locally in node_modules
+const pathAliasPlugin = require('@osd/babel-preset/path_alias');
+
 module.exports = function (api) {
   // ensure env is test so that this config won't impact build or dev server
   if (api.env('test')) {
@@ -19,6 +21,7 @@ module.exports = function (api) {
         require('@babel/preset-react'),
         require('@babel/preset-typescript'),
       ],
+      plugins: [pathAliasPlugin({})],
     };
   }
   return {};


### PR DESCRIPTION
### Description
The CI failed due to path alias introduced in OSD core, this PR fixed the CI failure.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
