### PR TITLE
Add new entry point in dashboard create dropdown

### DIFF
--- a/public/types.ts
+++ b/public/types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DashboardStart } from '../../../src/plugins/dashboard/public';
+import { DashboardSetup, DashboardStart } from '../../../src/plugins/dashboard/public';
 import { EmbeddableSetup, EmbeddableStart } from '../../../src/plugins/embeddable/public';
 import { IMessage, ISuggestedAction } from '../common/types/chat_saved_object_attributes';
 import { IChatContext } from './contexts/chat_context';
@@ -65,6 +65,7 @@ export interface AssistantPluginSetupDependencies {
   uiActions: UiActionsSetup;
   expressions: ExpressionsSetup;
   queryEnhancements: QueryEnhancementsPluginSetup;
+  dashboard: DashboardSetup;
 }
 
 export interface AssistantSetup {

--- a/public/ui_actions.tsx
+++ b/public/ui_actions.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { FormattedMessage } from '@osd/i18n/react';
+import { AssistantService } from './services/assistant_service';
+import { CoreSetup } from '../../../src/core/public';
+import { DataPublicPluginSetup } from '../../../src/plugins/data/public';
+import { TEXT2DASH_APP_ID } from './text2dash';
+import { DashboardSetup } from '../../../src/plugins/dashboard/public';
+
+interface Services {
+  core: CoreSetup;
+  data: DataPublicPluginSetup;
+  dashboard: DashboardSetup;
+  assistantService: AssistantService;
+}
+
+export function registerGenerateDashboardUIAction(services: Services) {
+  const { core, dashboard } = services;
+
+  dashboard.registerDashboardProvider({
+    savedObjectsType: 'text2dash',
+    savedObjectsName: 'Text2dash',
+    appId: TEXT2DASH_APP_ID,
+    viewUrlPathFn: (obj) => {
+      return `#/view/${obj.id}`;
+    },
+    editUrlPathFn: (obj) => {
+      return `/view/${obj.id}?_a=(viewMode:edit)`;
+    },
+    createUrl: core.http.basePath.prepend(`/app/${TEXT2DASH_APP_ID}#/`),
+    createSortText: 'Text2dash',
+    createLinkText: (
+      <FormattedMessage
+        id="dashboardAssistant.tableListView.listing.createNewItemButtonLabel"
+        defaultMessage="{entityName}"
+        values={{ entityName: 'AI generate' }}
+      />
+    ),
+  });
+}


### PR DESCRIPTION
### Description
This change modifies the Create Dashboard button to display a dropdown menu with two options: "Manual Create" (existing create page) and "AI Generate" (new entry point for the generative dashboard). The update enhances user experience by providing multiple dashboard creation methods in a single interface.

### Screenshot
![image](https://github.com/user-attachments/assets/6beaabb8-8d99-42ec-befc-091f93449149)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
