### PR TITLE
Add delete_backport_branch workflow

### DIFF
--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -1,0 +1,22 @@
+name: Delete merged branch of the backport PRs
+on: 
+  pull_request:
+    types:
+      - closed
+  
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
+    steps:
+    - name: Delete merged branch
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.git.deleteRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: `heads/${context.payload.pull_request.head.ref}`,
+          })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 ### Infrastructure
+- Add delete_backport_branch workflow to automatically delete branches that start with "backport/" or "release-chores/" after they are merged
 
 ### Documentation
 


### PR DESCRIPTION
This PR adds the delete_backport_branch workflow to automatically delete branches that start with 'backport/' or 'release-chores/' after they are merged. The workflow uses the actions/github-script@v7 action with proper permissions configuration.