### PR TITLE
Fix capability services access settings before login and show dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 - detect serverless data source ([#627](https://github.com/opensearch-project/dashboards-assistant/pull/627))
+- Fix capability services access settings before login and show dialog ([#628](https://github.com/opensearch-project/dashboards-assistant/pull/628))
 
 ### Infrastructure
 - Add delete_backport_branch workflow to automatically delete branches that start with "backport/" or "release-chores/" after they are merged

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -95,7 +95,9 @@ export class AssistantPlugin implements Plugin<AssistantPluginSetup, AssistantPl
             opensearchDashboardsRequest
           );
           const uiSettingsClient = coreStart.uiSettings.asScopedToClient(savedObjectsClient);
-          const isAssistantEnabledBySetting = await uiSettingsClient.get(ENABLE_AI_FEATURES);
+          const isAssistantEnabledBySetting = Boolean(
+            await uiSettingsClient.get(ENABLE_AI_FEATURES).catch(() => false)
+          );
 
           return {
             assistant: {


### PR DESCRIPTION
### Description
Refer to: https://github.com/opensearch-project/dashboards-investigation/pull/244

### Issues Resolved
OSD shows browser login dialog

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
