### PR TITLE
bug: Allow new conversation in loading process

### DIFF
--- a/public/services/__tests__/conversation_load_service.test.ts
+++ b/public/services/__tests__/conversation_load_service.test.ts
@@ -44,9 +44,9 @@ describe('ConversationLoadService', () => {
     expect(conversationLoad.status$.getValue()).toBe('idle');
   });
 
-  it('should emit error after loading aborted', async () => {
+  it('should emit idle status after loading aborted', async () => {
     const { conversationLoad, http } = setup();
-    const abortError = new Error('Aborted');
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
     http.get.mockImplementation(((_path, options) => {
       return new Promise((_resolve, reject) => {
         if (options?.signal) {
@@ -64,6 +64,16 @@ describe('ConversationLoadService', () => {
 
     await loadResult;
 
-    expect(conversationLoad.status$.getValue()).toEqual({ status: 'error', error: abortError });
+    expect(conversationLoad.status$.getValue()).toBe('idle');
+  });
+
+  it('should emit error for non-abort errors', async () => {
+    const { conversationLoad, http } = setup();
+    const networkError = new Error('Network error');
+    http.get.mockRejectedValue(networkError);
+
+    await conversationLoad.load('foo');
+
+    expect(conversationLoad.status$.getValue()).toEqual({ status: 'error', error: networkError });
   });
 });

--- a/public/services/__tests__/conversations_service.test.ts
+++ b/public/services/__tests__/conversations_service.test.ts
@@ -103,9 +103,9 @@ describe('ConversationsService', () => {
     });
   });
 
-  it('should emit error after loading aborted', async () => {
+  it('should emit idle status after loading aborted', async () => {
     const { conversations, http } = setup();
-    const abortError = new Error('Aborted');
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
     http.get.mockImplementation(((_path, options) => {
       return new Promise((_resolve, reject) => {
         if (options?.signal) {
@@ -123,7 +123,17 @@ describe('ConversationsService', () => {
 
     await loadResult;
 
-    expect(conversations.status$.getValue()).toEqual({ error: abortError });
+    expect(conversations.status$.getValue()).toBe('idle');
+  });
+
+  it('should emit error for non-abort errors', async () => {
+    const { conversations, http } = setup();
+    const networkError = new Error('Network error');
+    http.get.mockRejectedValue(networkError);
+
+    await conversations.load();
+
+    expect(conversations.status$.getValue()).toEqual({ error: networkError });
     expect(conversations.conversations$.getValue()).toEqual(null);
   });
 });

--- a/public/services/conversation_load_service.ts
+++ b/public/services/conversation_load_service.ts
@@ -43,6 +43,10 @@ export class ConversationLoadService {
       this.status$.next('idle');
       return payload;
     } catch (error) {
+      if (error.name === 'AbortError') {
+        this.status$.next('idle');
+        return;
+      }
       this.status$.next({ status: 'error', error });
     }
   };

--- a/public/services/conversations_service.ts
+++ b/public/services/conversations_service.ts
@@ -50,6 +50,10 @@ export class ConversationsService {
       );
       this.status$.next('idle');
     } catch (error) {
+      if (error.name === 'AbortError') {
+        this.status$.next('idle');
+        return;
+      }
       this.conversations$.next(null);
       this.status$.next({ error });
     }


### PR DESCRIPTION
### Description
Clicking on 'new conversation' during loading process generates an error message

<img width="884" height="602" alt="image" src="https://github.com/user-attachments/assets/8629f27e-004b-4db8-9b20-3632ef7d4f3b" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [ ] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
