### PR TITLE
fix: hide AI features for AnalyticEngine data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support log pattern in discover summary ([#550](https://github.com/opensearch-project/dashboards-assistant/pull/550))
 
 ### Bug Fixes
+- Hide AI features for AnalyticEngine data sources ([#689](https://github.com/opensearch-project/dashboards-assistant/pull/689))
 - detect serverless data source ([#627](https://github.com/opensearch-project/dashboards-assistant/pull/627))
 - Fix capability services access settings before login and show dialog ([#628](https://github.com/opensearch-project/dashboards-assistant/pull/628))
 - disable input panel and allow user click new conversation in error mode ([#639](https://github.com/opensearch-project/dashboards-assistant/pull/639))

--- a/server/routes/agent_routes.test.ts
+++ b/server/routes/agent_routes.test.ts
@@ -23,6 +23,83 @@ export const createMockedAssistantClient = (
 
 const mockedAssistantClient = createMockedAssistantClient({} as OpenSearchDashboardsRequest);
 
+const mockSavedObjectsClient = {
+  get: jest.fn(),
+};
+
+jest.mock('../../../../src/core/server/mocks', () => {
+  const original = jest.requireActual('../../../../src/core/server/mocks');
+  return {
+    ...original,
+    coreMock: {
+      ...original.coreMock,
+      createInternalStart: () => {
+        const start = original.coreMock.createInternalStart();
+        start.savedObjects.getScopedClient.mockReturnValue(mockSavedObjectsClient);
+        return start;
+      },
+    },
+  };
+});
+
+describe('test agentConfigExists route', () => {
+  const router = new Router(
+    '',
+    mockedLogger,
+    enhanceWithContext({
+      assistant_plugin: {
+        logger: mockedLogger,
+      },
+    })
+  );
+  registerAgentRoutes(router, {
+    getScopedClient: jest.fn(() => mockedAssistantClient),
+  });
+  const agentConfigExistsRequest = (query: {}) =>
+    triggerHandler(router, {
+      method: 'get',
+      path: AGENT_API.CONFIG_EXISTS,
+      req: httpServerMock.createRawRequest({ query }),
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMocks();
+  });
+
+  it('returns exists:false when data source is AnalyticEngine and config is os_suggest_ad', async () => {
+    mockSavedObjectsClient.get.mockResolvedValue({
+      attributes: { dataSourceEngineType: 'AnalyticEngine' },
+    });
+    const result = (await agentConfigExistsRequest({
+      dataSourceId: 'ds-1',
+      agentConfigName: 'os_suggest_ad',
+    })) as { source: { exists: boolean } };
+    expect(result.source).toEqual({ exists: false });
+  });
+
+  it('proceeds with normal check when data source is not AnalyticEngine', async () => {
+    mockSavedObjectsClient.get.mockResolvedValue({
+      attributes: { dataSourceEngineType: 'OpenSearch' },
+    });
+    mockedAssistantClient.getAgentIdByConfigName = jest.fn().mockResolvedValue('agent-id');
+    const result = (await agentConfigExistsRequest({
+      dataSourceId: 'ds-1',
+      agentConfigName: 'os_suggest_ad',
+    })) as { source: { exists: boolean } };
+    expect(result.source).toEqual({ exists: true });
+  });
+
+  it('proceeds with normal check when no dataSourceId is provided', async () => {
+    mockedAssistantClient.getAgentIdByConfigName = jest.fn().mockResolvedValue('agent-id');
+    const result = (await agentConfigExistsRequest({
+      agentConfigName: 'os_suggest_ad',
+    })) as { source: { exists: boolean } };
+    expect(result.source).toEqual({ exists: true });
+    expect(mockSavedObjectsClient.get).not.toHaveBeenCalled();
+  });
+});
+
 describe('test execute agent route', () => {
   const router = new Router(
     '',

--- a/server/routes/agent_routes.ts
+++ b/server/routes/agent_routes.ts
@@ -59,10 +59,28 @@ export function registerAgentRoutes(router: IRouter, assistantService: Assistant
     },
     router.handleLegacyErrors(async (context, req, res) => {
       try {
+        const { dataSourceId, agentConfigName } = req.query;
+        // Hide os_suggest_ad for AnalyticEngine data sources
+        const configNames = Array<string>().concat(agentConfigName);
+        if (dataSourceId && configNames.includes('os_suggest_ad')) {
+          try {
+            const savedObjectsClient = context.core.savedObjects.client;
+            const ds = await savedObjectsClient.get<{ dataSourceEngineType?: string }>(
+              'data-source',
+              dataSourceId
+            );
+            if (ds?.attributes?.dataSourceEngineType === 'AnalyticEngine') {
+              return res.ok({ body: { exists: false } });
+            }
+          } catch {
+            // Ignore errors, proceed with normal agent check
+          }
+        }
+
         const assistantClient = assistantService.getScopedClient(req, context);
-        const promises = Array<string>()
-          .concat(req.query.agentConfigName)
-          .map((configName) => assistantClient.getAgentIdByConfigName(configName));
+        const promises = configNames.map((configName) =>
+          assistantClient.getAgentIdByConfigName(configName)
+        );
         const results = await Promise.all(promises);
         const exists = results.every((r) => Boolean(r));
         return res.ok({ body: { exists } });


### PR DESCRIPTION
### Description
Fix `agentConfigExists` API returning `true` for AnalyticEngine data sources. Now returns `{ exists: false }` when the provided data source is AnalyticEngine and the config name is `os_suggest_ad`, which hides the "Suggest anomaly detector" action without requiring changes in external plugins.

### Issues Resolved
Refs opensearch-project/OpenSearch-Dashboards#11882
Related: opensearch-project/OpenSearch-Dashboards#12083

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test.
- [ ] New functionality has user manual doc added.
- [x] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).