### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/.lycheeexclude
+++ b/.lycheeexclude
@@ -3,3 +3,6 @@ https?://.+\$$
 
 https://bedrock-runtime.*.amazonaws.com/*
 https://link
+
+# local dev/test URLs (jest testEnvironmentOptions.url / process.env.HOST) are not reachable
+https?://localhost.*

--- a/common/utils/stream/stream_to_observable.test.ts
+++ b/common/utils/stream/stream_to_observable.test.ts
@@ -19,7 +19,7 @@ describe('convertEventStreamToObservable', () => {
     const mockedCallback = jest.fn();
     output$.subscribe(mockedCallback);
     await waitFor(() => {
-      expect(mockedCallback).toBeCalledWith('test');
+      expect(mockedCallback).toHaveBeenCalledWith('test');
     });
   });
 
@@ -42,8 +42,8 @@ describe('convertEventStreamToObservable', () => {
     await new Promise((resolve) => setTimeout(resolve, 500));
     cancel();
     await waitFor(() => {
-      expect(mockedCallback).toBeCalledTimes(1);
-      expect(mockedCompleteCallback).toBeCalledTimes(1);
+      expect(mockedCallback).toHaveBeenCalledTimes(1);
+      expect(mockedCompleteCallback).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/public/components/__snapshots__/agent_framework_traces.test.tsx.snap
+++ b/public/components/__snapshots__/agent_framework_traces.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<AgentFrameworkTraces/> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/__snapshots__/sidecar_icon_menu.test.tsx.snap
+++ b/public/components/__snapshots__/sidecar_icon_menu.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<SidecarIconMenu/> spec renders the component 1`] = `
 HTMLCollection [

--- a/public/components/agent_framework_traces.test.tsx
+++ b/public/components/agent_framework_traces.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { AgentFrameworkTraces } from './agent_framework_traces';
 import * as GetTraces from '../hooks/use_fetch_agentframework_traces';
@@ -53,7 +53,7 @@ describe('<AgentFrameworkTraces/> spec', () => {
     jest.spyOn(GetTraces, 'useFetchAgentFrameworkTraces').mockReturnValue(mockedGetTracesResult);
 
     render(<AgentFrameworkTraces interactionId="test-interaction-id" />);
-    expect(GetTraces.useFetchAgentFrameworkTraces).toBeCalledTimes(1);
+    expect(GetTraces.useFetchAgentFrameworkTraces).toHaveBeenCalledTimes(1);
     expect(document.body.children).toMatchSnapshot();
   });
 

--- a/public/components/agent_framework_traces_flyout_body.test.tsx
+++ b/public/components/agent_framework_traces_flyout_body.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { waitFor, render, screen, fireEvent } from '@testing-library/react';
 import * as chatContextExports from '../contexts/chat_context';
 import * as coreContextExports from '../contexts/core_context';

--- a/public/components/sidecar_icon_menu.test.tsx
+++ b/public/components/sidecar_icon_menu.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { SidecarIconMenu } from './sidecar_icon_menu';
 import * as chatContextExports from './../contexts/chat_context';

--- a/public/hooks/__snapshots__/use_patch_fixed_style.test.ts.snap
+++ b/public/hooks/__snapshots__/use_patch_fixed_style.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`usePatchFixedStyle hook should not subscribe update after unmount 1`] = `
 <head>

--- a/public/hooks/use_fetch_agentframework_traces.test.ts
+++ b/public/hooks/use_fetch_agentframework_traces.test.ts
@@ -114,7 +114,7 @@ describe('useFetchAgentFrameworkTraces hook', () => {
       );
 
       // expect the mock to be called
-      expect(abortFn).toBeCalledTimes(1);
+      expect(abortFn).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/public/hooks/use_get_chunks_from_http_response.test.tsx
+++ b/public/hooks/use_get_chunks_from_http_response.test.tsx
@@ -132,7 +132,7 @@ describe('useGetChunksFromHTTPResponse', () => {
         },
       });
 
-      expect(chatStateDispatchMock).toBeCalledWith({
+      expect(chatStateDispatchMock).toHaveBeenCalledWith({
         type: 'appendMessageContent',
         payload: {
           messageId: 'b',

--- a/public/tabs/chat/messages/message_action.test.tsx
+++ b/public/tabs/chat/messages/message_action.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { MessageActions } from './message_action';
 import { useFeedback } from '../../../hooks/use_feed_back';
 import { IOutput, Interaction } from '../../../../common/types/chat_saved_object_attributes';

--- a/public/utils/message_content_puller.test.ts
+++ b/public/utils/message_content_puller.test.ts
@@ -74,16 +74,16 @@ describe('MessageContentPool', () => {
 
     await waitFor(() => {
       expect(subscriptionMock).toHaveBeenCalledTimes(3);
-      expect(subscriptionMock).toBeCalledWith({
+      expect(subscriptionMock).toHaveBeenCalledWith({
         messageContent: 'a[hyperlink](href)',
         messageId: 'a',
       });
 
-      expect(subscriptionMock).toBeCalledWith({
+      expect(subscriptionMock).toHaveBeenCalledWith({
         messageContent: `[link whose length is larger than 50](${'a'.repeat(12)}`,
         messageId: 'b',
       });
-      expect(subscriptionMock).toBeCalledWith({
+      expect(subscriptionMock).toHaveBeenCalledWith({
         messageContent: `${'a'.repeat(39)})`,
         messageId: 'b',
       });

--- a/server/routes/get_conversation.test.ts
+++ b/server/routes/get_conversation.test.ts
@@ -71,7 +71,7 @@ describe('getConversation route', () => {
     const result = (await getConversationRequest({
       conversationId: '1',
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledTimes(1);
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1);
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},

--- a/server/routes/get_conversations.test.ts
+++ b/server/routes/get_conversations.test.ts
@@ -67,7 +67,7 @@ describe('getConversations route', () => {
       perPage: 10,
       page: 1,
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledTimes(2);
+    expect(mockedLogger.error).toHaveBeenCalledTimes(2);
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},

--- a/server/routes/regenerate.test.ts
+++ b/server/routes/regenerate.test.ts
@@ -119,7 +119,7 @@ describe('test regenerate route', () => {
       conversationId: 'foo',
       interactionId: 'bar',
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledTimes(1);
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1);
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},
@@ -148,8 +148,8 @@ describe('test regenerate route', () => {
       conversationId: 'foo',
       interactionId: 'bar',
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledTimes(1);
-    expect(mockedLogger.error).toBeCalledWith(new Error('foo'));
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockedLogger.error).toHaveBeenCalledWith(new Error('foo'));
     expect(result.output).toMatchInlineSnapshot(`
         Object {
           "headers": Object {},

--- a/server/routes/send_message.test.ts
+++ b/server/routes/send_message.test.ts
@@ -77,7 +77,7 @@ describe('test send_message route', () => {
         "title": "foo",
       }
     `);
-    expect(mockAgentFrameworkStorageService.getConversation).toBeCalledTimes(1);
+    expect(mockAgentFrameworkStorageService.getConversation).toHaveBeenCalledTimes(1);
   });
 
   it('should call getInteraction when conversationId is provided in request payload', async () => {
@@ -138,7 +138,7 @@ describe('test send_message route', () => {
         context: {},
       },
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledTimes(1);
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1);
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},
@@ -168,7 +168,7 @@ describe('test send_message route', () => {
         context: {},
       },
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledTimes(1);
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1);
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},
@@ -209,7 +209,7 @@ describe('test send_message route', () => {
       },
       conversationId: 'foo',
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledWith(new Error('something went wrong'));
+    expect(mockedLogger.error).toHaveBeenCalledWith(new Error('something went wrong'));
     expect(result.output).toMatchInlineSnapshot(`
       Object {
         "headers": Object {},
@@ -244,8 +244,8 @@ describe('test send_message route', () => {
         },
       },
     })) as Boom;
-    expect(mockedLogger.error).toBeCalledTimes(1);
-    expect(mockedLogger.error).toBeCalledWith(new Error('foo'));
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockedLogger.error).toHaveBeenCalledWith(new Error('foo'));
     expect(result.output).toMatchInlineSnapshot(`
         Object {
           "headers": Object {},

--- a/server/services/storage/agent_framework_storage_service.test.ts
+++ b/server/services/storage/agent_framework_storage_service.test.ts
@@ -458,7 +458,7 @@ describe('AgentFrameworkStorageService', () => {
     expect(agentFrameworkService.getInteraction('_id', '')).rejects.toMatchInlineSnapshot(
       `[Error: interactionId is required]`
     );
-    expect(mockedTransportRequest).toBeCalledTimes(0);
+    expect(mockedTransportRequest).toHaveBeenCalledTimes(0);
     expect(agentFrameworkService.getInteraction('_id', 'interaction_id')).resolves
       .toMatchInlineSnapshot(`
       Object {
@@ -468,7 +468,7 @@ describe('AgentFrameworkStorageService', () => {
         "response": "response",
       }
     `);
-    expect(mockedTransportRequest).toBeCalledTimes(1);
+    expect(mockedTransportRequest).toHaveBeenCalledTimes(1);
   });
 
   it('should encode id when calls getInteraction with non-standard params in request payload', async () => {

--- a/test/__mocks__/queryStringMock.js
+++ b/test/__mocks__/queryStringMock.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * query-string v9 is a pure ESM module whose index.js has only a default export.
+ * Under Jest's CJS transform the default-import interop can resolve to `undefined`.
+ * This shim (set as the moduleNameMapper target for 'query-string') loads the real
+ * package via an absolute node_modules path so the mapper does not recurse, and
+ * normalises the export shape back to a default export.
+ *
+ * The plugin has no local query-string; it lives in the parent repo's node_modules,
+ * so resolve relative to this file (test/__mocks__ -> ../../../../node_modules).
+ */
+
+const path = require('path');
+// eslint-disable-next-line import/no-dynamic-require
+const mod = require(path.resolve(__dirname, '../../../../node_modules/query-string/index.js'));
+
+// After the Babel + babel-plugin-add-module-exports pipeline, `mod` may be the raw
+// namespace object `{ __esModule: true, stringify, parse, ... }` with no `.default`.
+// Recover the actual API regardless of which shape we receive.
+const api = mod && mod.__esModule && typeof mod.stringify !== 'function' ? mod.default : mod;
+
+module.exports = {
+  __esModule: true,
+  default: api,
+};

--- a/test/__mocks__/rawLoaderMock.js
+++ b/test/__mocks__/rawLoaderMock.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Stub for `!!raw-loader!` imports. jest-raw-loader is incompatible with the
+// Jest 28+ transformer API and was removed during the Jest 30 upgrade. No test
+// asserts the real raw file contents (the only consumer mocks the import
+// directly), so a string stub preserves the prior behaviour.
+module.exports = 'raw-loader-stub';

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -37,7 +37,7 @@ module.exports = {
     url: 'http://localhost:5601',
   },
   // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
-  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/upgrading-to-jest29
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -8,7 +8,7 @@ process.env.TZ = 'UTC';
 module.exports = {
   rootDir: '../',
   setupFiles: ['<rootDir>/test/setupTests.ts'],
-  setupFilesAfterEnv: ['<rootDir>/test/setup.jest.ts'],
+  setupFilesAfterEnv: ['jest-location-mock', '<rootDir>/test/setup.jest.ts'],
   roots: ['<rootDir>'],
   testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
   clearMocks: true,
@@ -24,13 +24,27 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|less|sass|scss)$': '<rootDir>/test/__mocks__/styleMock.js',
     '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/test/__mocks__/fileMock.js',
-    '^!!raw-loader!.*': 'jest-raw-loader',
+    '^!!raw-loader!.*': '<rootDir>/test/__mocks__/rawLoaderMock.js',
+    // query-string v9 is pure ESM; this shim restores the default-import shape
+    // (`import qs from 'query-string'`) under Jest's CJS transform.
+    '^query-string$': '<rootDir>/test/__mocks__/queryStringMock.js',
     '@hapi/hoek/(?!lib/)(.*)': '<rootDir>/../../node_modules/@hapi/hoek/lib/$1',
   },
   testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    // Set the default URL so window.location.origin is 'http://localhost:5601' rather than
+    // 'http://localhost', avoiding the need for tests to mock window.location.origin.
+    url: 'http://localhost:5601',
+  },
+  // Retain Jest 28 snapshot defaults; Jest 29 flipped escapeString and printBasicPrototype to false,
+  // which would invalidate existing snapshots. See https://jestjs.io/docs/29.0/upgrading-to-jest29
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
   transformIgnorePatterns: [
     // ignore all node_modules except those which require babel transforms to handle dynamic import()
     // since ESM modules are not natively supported in Jest yet (https://github.com/facebook/jest/issues/4842)
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|weak-lru-cache|ordered-binary|d3-color|axios|query-string|decode-uri-component|filter-obj|split-on-first))[/\\\\].+\\.js$',
   ],
 };

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -17,7 +17,7 @@ window.URL.createObjectURL = () => '';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 HTMLCanvasElement.prototype.getContext = () => '' as any;
 Element.prototype.scrollIntoView = jest.fn();
-window.IntersectionObserver = (class IntersectionObserver {
+window.IntersectionObserver = class IntersectionObserver {
   constructor() {}
 
   disconnect() {
@@ -35,7 +35,7 @@ window.IntersectionObserver = (class IntersectionObserver {
   unobserve() {
     return null;
   }
-} as unknown) as typeof window.IntersectionObserver;
+} as unknown as typeof window.IntersectionObserver;
 
 jest.mock('@elastic/eui/lib/components/form/form_row/make_id', () => () => 'random-id');
 
@@ -47,9 +47,15 @@ jest.mock('@elastic/eui/lib/services/accessibility/html_id_generator', () => ({
 
 jest.setTimeout(30000);
 
+// jest-location-mock uses process.env.HOST as the base URL for its window.location mock.
+// Set it to match testEnvironmentOptions.url so window.location.origin is 'http://localhost:5601'
+// in all jsdom tests, consistent with the rest of the suite.
+process.env.HOST = 'http://localhost:5601';
+
 // Mock window.matchMedia for Monaco editor
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
+  configurable: true,
   value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
@@ -60,4 +66,18 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
   })),
+});
+
+// jsdom 26 marks window.localStorage and window.sessionStorage as non-configurable.
+// Re-declare them as configurable once here so individual tests can override them
+// with Object.defineProperty without hitting "Cannot redefine property" errors.
+['localStorage', 'sessionStorage'].forEach((key) => {
+  const descriptor = Object.getOwnPropertyDescriptor(window, key);
+  if (descriptor && !descriptor.configurable) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value: descriptor.value,
+    });
+  }
 });


### PR DESCRIPTION
Closes #716

### Description

Migrate this plugin's Jest test suite to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary, so it breaks once the core upgrade lands.

**Result:** full suite green — `73 suites / 458 tests / 89 snapshots passed`, exit 0.

#### Common changes (shared across the plugin-migration campaign)
- **Config (`test/jest.config.js`):** added `jest-location-mock` as the first `setupFilesAfterEnv`
  entry; added `testEnvironmentOptions: { url: 'http://localhost:5601' }` so `window.location.origin`
  matches the suite's expected host; added the
  `snapshotFormat: { escapeString: true, printBasicPrototype: true }` compatibility shim (Jest 29
  flipped these defaults, which would otherwise invalidate existing snapshots); replaced the
  `jest-raw-loader` moduleNameMapper with a local stub (`test/__mocks__/rawLoaderMock.js`) since
  jest-raw-loader is incompatible with the Jest 28+ transformer API.
- **Setup (`test/setup.jest.ts`):** made the `matchMedia` mock `configurable`; set
  `process.env.HOST = 'http://localhost:5601'` (the base URL jest-location-mock uses); re-declared
  the now non-configurable `localStorage`/`sessionStorage` as configurable so individual tests can
  still override them (jsdom 26).
- **jest-dom import fix:** replaced the removed `@testing-library/jest-dom/extend-expect` import with
  `@testing-library/jest-dom` across 4 test files (`agent_framework_traces.test.tsx`,
  `agent_framework_traces_flyout_body.test.tsx`, `sidecar_icon_menu.test.tsx`,
  `tabs/chat/messages/message_action.test.tsx`).
- **Matcher codemod:** `toBeCalled*` → `toHaveBeenCalled*` across 10 test files (Jest 30 removed the
  aliases). No `toThrowError` usages were present.
- **Snapshots:** bumped the snapshot header URL (`goo.gl/fbAQLP` →
  `jestjs.io/docs/snapshot-testing`) in the 3 `.snap` files that had it — Jest 30 refuses to load the
  old header. All 3 diffs are header-only; no snapshot content was regenerated or changed
  (serialization-only verification: zero body diffs).

#### Plugin-specific changes
- **`query-string` v9 ESM fix** — this is the distinctive breakage for this plugin. query-string v9
  is pure ESM whose `index.js` exposes only a default export, and under Jest's CJS transform the
  default-import interop can resolve to `undefined`. Two coordinated fixes in `test/jest.config.js`:
  - Added a `moduleNameMapper` entry `'^query-string$' -> '<rootDir>/test/__mocks__/queryStringMock.js'`.
    The new **`test/__mocks__/queryStringMock.js`** shim loads the real package via an absolute
    `node_modules/query-string/index.js` path (so the mapper does not recurse) and normalises the
    export shape back to a `{ __esModule: true, default }` form regardless of what the Babel +
    `babel-plugin-add-module-exports` pipeline produces.
  - Extended `transformIgnorePatterns` to also transform `query-string` and its ESM dependency chain
    (`decode-uri-component`, `filter-obj`, `split-on-first`) instead of ignoring them.

No `package.json` change was needed — the plugin inherits the parent repo's Jest 30 / jsdom 26 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<issue> -->

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
