### PR TITLE
fix(ci): downgrade codecov-action to v4 to fix GPG validation failures

### DIFF
--- a/.github/workflows/unit_test_workflow.yml
+++ b/.github/workflows/unit_test_workflow.yml
@@ -111,7 +111,7 @@ jobs:
           name: coverage-report-linux
           path: ./coverage
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage


### PR DESCRIPTION
### Description

Downgrades `codecov/codecov-action` from v5 to v4 (pinned to SHA `b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238`).

v5 fails with `gpg: no valid OpenPGP data found` / `Can't check signature: No public key` during signature verification because it fetches PGP keys from an external source that is intermittently unavailable. v4 bundles `pgp_keys.asc` locally, avoiding the external fetch entirely.

This is the same fix applied to [dashboards-investigation#394](https://github.com/opensearch-project/dashboards-investigation/pull/394).

### Issues Resolved

Fixes the `tests-codecov` CI job failing on all PRs.

### Check List
- [x] All tests pass, including unit test, integration test.
- [x] Commits are signed per the DCO using --signoff.