### PR TITLE
Add configurable assistant.chat.traceMaxResults setting for agent trace steps

### DIFF
--- a/common/types/config.ts
+++ b/common/types/config.ts
@@ -10,6 +10,7 @@ export const configSchema = schema.object({
   chat: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
     trace: schema.boolean({ defaultValue: true }),
+    traceMaxResults: schema.number({ defaultValue: 10, min: 1 }),
     feedback: schema.boolean({ defaultValue: true }),
     allowRenameConversation: schema.boolean({ defaultValue: true }),
     deleteConversation: schema.boolean({ defaultValue: true }),

--- a/server/routes/chat_routes.test.ts
+++ b/server/routes/chat_routes.test.ts
@@ -38,6 +38,11 @@ const router = new Router(
   enhanceWithContext({
     assistant_plugin: {
       logger: mockedLogger,
+      config: {
+        chat: {
+          traceMaxResults: 10,
+        },
+      },
     },
   })
 );
@@ -257,7 +262,7 @@ describe('chat routes', () => {
       expect(mockAgentFrameworkStorageService.getTraces).not.toHaveBeenCalled();
       const result = (await triggerGetTrace('interaction-1')) as ResponseObject;
       expect(getOpenSearchClientTransport.mock.results[0].value).toBe('client');
-      expect(mockAgentFrameworkStorageService.getTraces).toHaveBeenCalledWith('interaction-1');
+      expect(mockAgentFrameworkStorageService.getTraces).toHaveBeenCalledWith('interaction-1', 10);
       expect(result.source).toEqual(getTraceResultMock);
     });
 
@@ -277,7 +282,7 @@ describe('chat routes', () => {
       expect(mockAgentFrameworkStorageService.getTraces).not.toHaveBeenCalled();
       const result = (await triggerGetTrace('interaction-1', 'data_source_id')) as ResponseObject;
       expect(getOpenSearchClientTransport.mock.results[0].value).toBe('dataSource-client');
-      expect(mockAgentFrameworkStorageService.getTraces).toHaveBeenCalledWith('interaction-1');
+      expect(mockAgentFrameworkStorageService.getTraces).toHaveBeenCalledWith('interaction-1', 10);
       expect(result.source).toEqual(getTraceResultMock);
     });
 

--- a/server/routes/chat_routes.ts
+++ b/server/routes/chat_routes.ts
@@ -364,9 +364,13 @@ export function registerChatRoutes(router: IRouter, routeOptions: RoutesOptions)
       response
     ): Promise<IOpenSearchDashboardsResponse<HttpResponsePayload | ResponseError>> => {
       const storageService = await createStorageService(context, request.query.dataSourceId);
+      const maxResults = context.assistant_plugin.config.chat.traceMaxResults;
 
       try {
-        const getResponse = await storageService.getTraces(request.params.interactionId);
+        const getResponse = await storageService.getTraces(
+          request.params.interactionId,
+          maxResults
+        );
         return response.ok({ body: getResponse });
       } catch (error) {
         context.assistant_plugin.logger.error(error);

--- a/server/services/storage/agent_framework_storage_service.test.ts
+++ b/server/services/storage/agent_framework_storage_service.test.ts
@@ -361,10 +361,22 @@ describe('AgentFrameworkStorageService', () => {
       Array [
         Object {
           "method": "GET",
-          "path": "/_plugins/_ml/memory/message/..%2Fnon-standard%2Fid/traces",
+          "path": "/_plugins/_ml/memory/message/..%2Fnon-standard%2Fid/traces?max_results=10",
         },
       ]
     `);
+  });
+
+  it('passes maxResults to the traces request', async () => {
+    mockedTransportRequest.mockResolvedValueOnce({
+      body: {
+        traces: [],
+      },
+    });
+    await agentFrameworkService.getTraces('foo', 1000);
+    expect(mockedTransportRequest.mock.calls[0][0].path).toEqual(
+      '/_plugins/_ml/memory/message/foo/traces?max_results=1000'
+    );
   });
 
   it('updateInteraction', async () => {

--- a/server/services/storage/agent_framework_storage_service.ts
+++ b/server/services/storage/agent_framework_storage_service.ts
@@ -187,10 +187,12 @@ export class AgentFrameworkStorageService implements StorageService {
     }
   }
 
-  async getTraces(interactionId: string): Promise<AgentFrameworkTrace[]> {
+  async getTraces(interactionId: string, maxResults = 10): Promise<AgentFrameworkTrace[]> {
     const response = (await this.clientTransport.request({
       method: 'GET',
-      path: `${ML_COMMONS_BASE_API}/memory/message/${encodeURIComponent(interactionId)}/traces`,
+      path: `${ML_COMMONS_BASE_API}/memory/message/${encodeURIComponent(
+        interactionId
+      )}/traces?max_results=${maxResults}`,
     })) as ApiResponse<{
       traces: Array<{
         message_id: string;

--- a/server/types.ts
+++ b/server/types.ts
@@ -5,6 +5,7 @@
 
 import { IMessage, Interaction } from '../common/types/chat_saved_object_attributes';
 import { Logger, HttpAuth } from '../../../src/core/server';
+import { ConfigSchema } from '../common/types/config';
 import { AssistantServiceSetup } from './services/assistant_service';
 
 export interface AssistantPluginSetup {
@@ -49,6 +50,7 @@ declare module '../../../src/core/server' {
   interface RequestHandlerContext {
     assistant_plugin: {
       logger: Logger;
+      config: ConfigSchema;
     };
   }
 }


### PR DESCRIPTION
…ce steps

### Description

The agent trace view ("How was this generated") in the assistant only ever shows the first 10 tool steps, even when an agent invoked more tools.

The UI component (`public/components/agent_framework_traces.tsx`) maps over all traces it receives, so it is not the source of the cap. The server (`AgentFrameworkStorageService.getTraces`) requests traces from ml-commons
without a `max_results` parameter: 

GET /_plugins/_ml/memory/message/{interactionId}/traces

ml-commons then applies its default page size of 10 (`ActionConstants.DEFAULT_MAX_RESULTS`), truncating the returned traces.

This PR adds a server-side setting `assistant.chat.traceMaxResults` (default `10`, preserving current behavior) that is passed through to the traces request, mirroring the existing `/messages?max_results=1000` pattern used for conversation messages.

### Changes
- `common/types/config.ts`: add `chat.traceMaxResults` number setting (default 10, min 1).
- `server/types.ts`: expose `config` on the `assistant_plugin` request handler context type.
- `server/services/storage/agent_framework_storage_service.ts`: `getTraces` now accepts a `maxResults` argument and appends `?max_results=`.
- `server/routes/chat_routes.ts`: pass the configured value into `getTraces`.
- Tests updated + added coverage that `maxResults` is forwarded to the request.

### Configuration
```yaml
assistant.chat.traceMaxResults: 1000
```

### Issues Resolved
Closes [#729 ](https://github.com/opensearch-project/dashboards-assistant/issues/729)

### Check List
- [X]  New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test.
- [X] New functionality has user manual doc added.
- [X] Commits are signed per the DCO using --signoff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
